### PR TITLE
chore: remove stale relay references from comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,25 +535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "egregore-relay"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "axum",
- "base64",
- "chrono",
- "clap",
- "ed25519-dalek",
- "egregore",
- "serde",
- "serde_json",
- "tokio",
- "tower-http 0.5.2",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/feed/store/mod.rs
+++ b/src/feed/store/mod.rs
@@ -5,8 +5,8 @@
 //! Peer storage uses two tables:
 //! - `peers`: address-keyed, from manual add or LAN discovery. Identity unknown
 //!   until first successful SHS handshake backfills public_id.
-//! - `known_peers`: public_id-keyed, from relay registration or completed
-//!   handshakes. Tracks authorization, privacy, timestamps.
+//! - `known_peers`: public_id-keyed, from completed handshakes. Tracks
+//!   authorization, privacy, timestamps.
 //!
 //! Both contribute to the sync loop's peer list via `list_all_syncable_addresses()`
 //! (SQL UNION, deduplicated).

--- a/src/feed/store/peers.rs
+++ b/src/feed/store/peers.rs
@@ -1,7 +1,7 @@
 //! Peer storage operations across two tables.
 //!
 //! `peers` (address-keyed): created by manual add or LAN discovery.
-//! `known_peers` (public_id-keyed): created by relay registration or gossip.
+//! `known_peers` (public_id-keyed): created by completed gossip handshakes.
 //!
 //! The sync loop queries both for addresses to connect to.
 

--- a/src/gossip/server.rs
+++ b/src/gossip/server.rs
@@ -4,9 +4,8 @@
 //! bidirectional replication. Authorization runs AFTER handshake succeeds
 //! (identity is verified before the authorization check).
 //!
-//! Node mode: no authorization — accepts any peer on the same network key.
-//! Relay mode: AuthorizeFn checks known_peers.authorized in the database,
-//!   rejecting peers that haven't called POST /v1/register.
+//! Default: no authorization — accepts any peer on the same network key.
+//! With AuthorizeFn: checks known_peers.authorized, rejecting unauthorized peers.
 //!
 //! Bounded by semaphore (64 concurrent) and per-connection timeout (120s)
 //! to prevent resource exhaustion.


### PR DESCRIPTION
## Summary

Removes stale relay references from code comments after PR #11 removed relay functionality.

- `peers.rs:4`: "relay registration or gossip" → "completed gossip handshakes"
- `mod.rs:8`: "relay registration or completed" → "completed"
- `server.rs:7-8`: "Node mode / Relay mode" → "Default / With AuthorizeFn"

Peer authorization code (`is_peer_authorized`, `AuthorizeFn`) is retained for potential future node-to-node use cases (allowlist/blocklist).

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)