### PR TITLE
feat: YAML config file with multi-hook support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tempfile",
  "thiserror",
@@ -1815,6 +1816,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,6 +2282,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 
 # TCP framing
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,24 +1,36 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 /// Default network key (SHA-256 of "egregore-network-v1").
 /// Different keys create isolated networks.
 const DEFAULT_NETWORK_KEY: &str = "egregore-network-v1";
 
-/// Hook configuration for event-driven message handling.
+/// A single hook definition. Each hook can be a subprocess, a webhook, or both.
+/// Each hook has its own filter and timeout.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct HookConfig {
+pub struct HookEntry {
+    /// Human-readable label for logging.
+    #[serde(default)]
+    pub name: Option<String>,
     /// Path to executable called when a message arrives.
     /// Message JSON is passed on stdin.
     pub on_message: Option<PathBuf>,
     /// URL to POST message JSON to when a message arrives.
-    /// Can be used alongside on_message (both will fire).
     pub webhook_url: Option<String>,
     /// Optional content type filter (e.g., "query", "insight").
-    /// If set, hooks only fire for messages matching this type.
+    /// If set, hook only fires for messages matching this type.
     pub filter_content_type: Option<String>,
     /// Timeout in seconds for hook/webhook execution (default: 30).
     pub timeout_secs: Option<u64>,
+}
+
+impl HookEntry {
+    /// Returns true if this entry has at least one actionable handler.
+    pub fn is_active(&self) -> bool {
+        self.on_message.is_some() || self.webhook_url.is_some()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,9 +43,9 @@ pub struct Config {
     pub peers: Vec<String>,
     pub lan_discovery: bool,
     pub discovery_port: u16,
-    /// Hook configuration for event-driven handlers.
+    /// Multiple hook configurations for event-driven handlers.
     #[serde(default)]
-    pub hooks: HookConfig,
+    pub hooks: Vec<HookEntry>,
 }
 
 impl Default for Config {
@@ -47,7 +59,7 @@ impl Default for Config {
             peers: Vec::new(),
             lan_discovery: false,
             discovery_port: 7656,
-            hooks: HookConfig::default(),
+            hooks: Vec::new(),
         }
     }
 }
@@ -59,6 +71,68 @@ impl Config {
 
     pub fn db_path(&self) -> PathBuf {
         self.data_dir.join("egregore.db")
+    }
+
+    /// Returns the default config file path for a given data directory.
+    pub fn config_file_path(data_dir: &Path) -> PathBuf {
+        data_dir.join("config.yaml")
+    }
+
+    /// Load config from a YAML file. Returns None if the file does not exist.
+    pub fn load_from_file(path: &Path) -> anyhow::Result<Option<Config>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read config file: {}", path.display()))?;
+        let config: Config = serde_yaml::from_str(&contents)
+            .with_context(|| format!("failed to parse config file: {}", path.display()))?;
+        Ok(Some(config))
+    }
+
+    /// Write a default config file with documentation comments.
+    /// Returns an error if the file already exists (to prevent accidental overwrite).
+    pub fn write_default_config(path: &Path) -> anyhow::Result<()> {
+        if path.exists() {
+            anyhow::bail!(
+                "config file already exists: {}. Remove it first to regenerate.",
+                path.display()
+            );
+        }
+        let template = include_str!("config_template.yaml");
+        std::fs::write(path, template)
+            .with_context(|| format!("failed to write config file: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Validate the config for obvious errors.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.port == self.gossip_port {
+            anyhow::bail!("port and gossip_port must differ ({} == {})", self.port, self.gossip_port);
+        }
+        if self.port == self.discovery_port || self.gossip_port == self.discovery_port {
+            anyhow::bail!(
+                "discovery_port ({}) must differ from port ({}) and gossip_port ({})",
+                self.discovery_port, self.port, self.gossip_port
+            );
+        }
+        for hook in &self.hooks {
+            if let Some(ref path) = hook.on_message {
+                if !path.exists() {
+                    tracing::warn!(
+                        hook_name = ?hook.name,
+                        path = %path.display(),
+                        "hook script does not exist"
+                    );
+                }
+            }
+            if let Some(ref url) = hook.webhook_url {
+                if !url.starts_with("http://") && !url.starts_with("https://") {
+                    anyhow::bail!("webhook_url must start with http:// or https://: {}", url);
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn network_key_bytes(&self) -> [u8; 32] {
@@ -110,5 +184,94 @@ mod tests {
         let disc = config.network_key_discriminator();
         // Discriminator should NOT be a prefix of the network key
         assert_ne!(&nk[..8], &disc[..]);
+    }
+
+    #[test]
+    fn hook_entry_is_active() {
+        let empty = HookEntry::default();
+        assert!(!empty.is_active());
+
+        let with_path = HookEntry {
+            on_message: Some(PathBuf::from("/bin/true")),
+            ..Default::default()
+        };
+        assert!(with_path.is_active());
+
+        let with_url = HookEntry {
+            webhook_url: Some("https://example.com".to_string()),
+            ..Default::default()
+        };
+        assert!(with_url.is_active());
+    }
+
+    #[test]
+    fn yaml_round_trip() {
+        let config = Config {
+            peers: vec!["192.168.1.100:7655".to_string()],
+            hooks: vec![
+                HookEntry {
+                    name: Some("test-hook".to_string()),
+                    on_message: Some(PathBuf::from("./hooks/test.sh")),
+                    filter_content_type: Some("insight".to_string()),
+                    timeout_secs: Some(10),
+                    ..Default::default()
+                },
+                HookEntry {
+                    name: Some("webhook".to_string()),
+                    webhook_url: Some("https://example.com/hook".to_string()),
+                    ..Default::default()
+                },
+            ],
+            ..Config::default()
+        };
+
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let parsed: Config = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(parsed.peers.len(), 1);
+        assert_eq!(parsed.hooks.len(), 2);
+        assert_eq!(parsed.hooks[0].name.as_deref(), Some("test-hook"));
+        assert_eq!(parsed.hooks[1].webhook_url.as_deref(), Some("https://example.com/hook"));
+    }
+
+    #[test]
+    fn yaml_empty_hooks_defaults() {
+        let yaml = "data_dir: ./data\nport: 7654\ngossip_port: 7655\ngossip_interval_secs: 300\nnetwork_key: test\npeers: []\nlan_discovery: false\ndiscovery_port: 7656\n";
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.hooks.is_empty());
+    }
+
+    #[test]
+    fn validate_port_conflict() {
+        let config = Config {
+            port: 7654,
+            gossip_port: 7654,
+            ..Config::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_bad_webhook_url() {
+        let config = Config {
+            hooks: vec![HookEntry {
+                webhook_url: Some("not-a-url".to_string()),
+                ..Default::default()
+            }],
+            ..Config::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_good_config() {
+        let config = Config {
+            hooks: vec![HookEntry {
+                webhook_url: Some("https://example.com/hook".to_string()),
+                ..Default::default()
+            }],
+            ..Config::default()
+        };
+        assert!(config.validate().is_ok());
     }
 }

--- a/src/config_template.yaml
+++ b/src/config_template.yaml
@@ -1,0 +1,62 @@
+# Egregore Node Configuration
+#
+# CLI flags override values in this file.
+# Delete or comment out any field to use its default.
+
+# Data directory for identity and database.
+# Default: ./data
+data_dir: ./data
+
+# HTTP API port (localhost only).
+# Default: 7654
+port: 7654
+
+# Gossip TCP port (binds to all interfaces).
+# Default: 7655
+gossip_port: 7655
+
+# Seconds between gossip sync cycles.
+# Default: 300 (5 minutes)
+gossip_interval_secs: 300
+
+# Network key for isolation. Nodes with different keys cannot communicate.
+# Default: egregore-network-v1
+network_key: egregore-network-v1
+
+# Enable UDP LAN peer discovery.
+# Default: false
+lan_discovery: false
+
+# UDP port for LAN discovery broadcasts.
+# Default: 7656
+discovery_port: 7656
+
+# Static peer addresses for gossip replication.
+# Merged with peers discovered via LAN and stored in the database.
+# CLI --peer flags append to this list.
+# Format: host:port
+#
+# Example:
+# peers:
+#   - 192.168.1.100:7655
+#   - relay.example.com:7661
+peers: []
+
+# Hook definitions. Each hook fires independently on message events.
+# Hooks run in parallel. Each can have its own filter and timeout.
+# CLI --hook-on-message/--hook-webhook-url append an additional hook.
+#
+# Example:
+# hooks:
+#   - name: discord-notify
+#     on_message: ./hooks/discord-notify.sh
+#     timeout_secs: 10
+#   - name: insight-webhook
+#     webhook_url: https://example.com/hooks/egregore
+#     filter_content_type: insight
+#     timeout_secs: 15
+#   - name: full-pipeline
+#     on_message: ./hooks/process.sh
+#     webhook_url: https://example.com/hooks/backup
+#     timeout_secs: 30
+hooks: []

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,13 @@
 
 mod api;
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser};
 use std::path::PathBuf;
 
-use egregore::config::{Config, HookConfig};
+use egregore::config::{Config, HookEntry};
 use egregore::feed::engine::FeedEngine;
 use egregore::feed::store::FeedStore;
 use egregore::gossip;
@@ -24,6 +25,10 @@ use egregore::identity::Identity;
 #[derive(Parser)]
 #[command(name = "egregore", version, about = "SSB-inspired LLM knowledge sharing")]
 struct Cli {
+    /// Path to YAML config file (default: <data_dir>/config.yaml)
+    #[arg(long)]
+    config: Option<PathBuf>,
+
     /// Data directory for identity and database
     #[arg(long, default_value = "./data")]
     data_dir: PathBuf,
@@ -44,7 +49,7 @@ struct Cli {
     #[arg(long, default_value = "egregore-network-v1")]
     network_key: String,
 
-    /// Peer addresses (host:port)
+    /// Peer addresses (host:port). Repeatable. Appends to config file peers.
     #[arg(long)]
     peer: Vec<String>,
 
@@ -56,17 +61,101 @@ struct Cli {
     #[arg(long, default_value_t = 7656)]
     discovery_port: u16,
 
-    /// Path to hook script called when messages arrive
+    /// Gossip sync interval in seconds
+    #[arg(long)]
+    gossip_interval_secs: Option<u64>,
+
+    /// Path to hook script called when messages arrive (use config file for multiple hooks)
     #[arg(long)]
     hook_on_message: Option<PathBuf>,
 
-    /// URL to POST message JSON when messages arrive
+    /// URL to POST message JSON when messages arrive (use config file for multiple hooks)
     #[arg(long)]
     hook_webhook_url: Option<String>,
 
     /// Filter hooks to specific content type (e.g., "query")
     #[arg(long)]
     hook_filter_type: Option<String>,
+
+    /// Hook timeout in seconds
+    #[arg(long)]
+    hook_timeout_secs: Option<u64>,
+
+    /// Generate a default config.yaml in data-dir and exit
+    #[arg(long)]
+    init_config: bool,
+}
+
+/// Build the final Config by merging: defaults -> YAML file -> CLI overrides.
+fn build_config(cli: &Cli, matches: &clap::ArgMatches) -> anyhow::Result<Config> {
+    use clap::parser::ValueSource;
+
+    // Phase 1: data_dir always comes from CLI (needed to locate config file)
+    let data_dir = cli.data_dir.clone();
+
+    // Phase 2: Load YAML config if it exists
+    let config_path = cli.config.clone()
+        .unwrap_or_else(|| Config::config_file_path(&data_dir));
+
+    let mut config = match Config::load_from_file(&config_path)? {
+        Some(file_config) => {
+            tracing::info!(path = %config_path.display(), "loaded config file");
+            file_config
+        }
+        None => {
+            tracing::debug!(path = %config_path.display(), "no config file found, using defaults");
+            Config::default()
+        }
+    };
+
+    // Phase 3: CLI overrides — only apply values the user explicitly passed
+    // data_dir: if the user explicitly passed --data-dir, use CLI value.
+    // Otherwise keep the YAML value (which defaults to "./data" if unset).
+    if matches.value_source("data_dir") == Some(ValueSource::CommandLine) {
+        config.data_dir = data_dir;
+    }
+
+    if matches.value_source("port") == Some(ValueSource::CommandLine) {
+        config.port = cli.port;
+    }
+    if matches.value_source("gossip_port") == Some(ValueSource::CommandLine) {
+        config.gossip_port = cli.gossip_port;
+    }
+    if matches.value_source("network_key") == Some(ValueSource::CommandLine) {
+        config.network_key = cli.network_key.clone();
+    }
+    if matches.value_source("discovery_port") == Some(ValueSource::CommandLine) {
+        config.discovery_port = cli.discovery_port;
+    }
+    if matches.value_source("lan_discovery") == Some(ValueSource::CommandLine) {
+        config.lan_discovery = cli.lan_discovery;
+    }
+    if let Some(interval) = cli.gossip_interval_secs {
+        config.gossip_interval_secs = interval;
+    }
+
+    // Peers: CLI --peer appends to config file peers (deduplicated)
+    if !cli.peer.is_empty() {
+        config.peers.extend(cli.peer.iter().cloned());
+        let mut seen = HashSet::new();
+        config.peers.retain(|p| seen.insert(p.clone()));
+    }
+
+    // CLI hook flags create one additional hook entry appended to config file hooks
+    let cli_hook = HookEntry {
+        name: Some("cli".to_string()),
+        on_message: cli.hook_on_message.clone(),
+        webhook_url: cli.hook_webhook_url.clone(),
+        filter_content_type: cli.hook_filter_type.clone(),
+        timeout_secs: cli.hook_timeout_secs,
+    };
+    if cli_hook.is_active() {
+        config.hooks.push(cli_hook);
+    }
+
+    config.validate()?;
+
+    Ok(config)
 }
 
 #[tokio::main]
@@ -78,26 +167,19 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let cli = Cli::parse();
+    let mut matches = Cli::command().get_matches();
+    let cli = Cli::from_arg_matches_mut(&mut matches)?;
 
-    let hooks = HookConfig {
-        on_message: cli.hook_on_message,
-        webhook_url: cli.hook_webhook_url,
-        filter_content_type: cli.hook_filter_type,
-        timeout_secs: Some(30),
-    };
+    // Handle --init-config
+    if cli.init_config {
+        std::fs::create_dir_all(&cli.data_dir)?;
+        let config_path = Config::config_file_path(&cli.data_dir);
+        Config::write_default_config(&config_path)?;
+        println!("Config written to {}", config_path.display());
+        return Ok(());
+    }
 
-    let config = Config {
-        data_dir: cli.data_dir,
-        port: cli.port,
-        gossip_port: cli.gossip_port,
-        network_key: cli.network_key,
-        peers: cli.peer,
-        lan_discovery: cli.lan_discovery,
-        discovery_port: cli.discovery_port,
-        hooks,
-        ..Config::default()
-    };
+    let config = build_config(&cli, &matches)?;
 
     // Ensure data directory exists
     std::fs::create_dir_all(&config.data_dir)?;
@@ -123,13 +205,20 @@ async fn main() -> anyhow::Result<()> {
 
     // Start hook executor if configured
     if let Some(executor) = HookExecutor::new(config.hooks.clone()) {
+        let hook_count = config.hooks.iter().filter(|h| h.is_active()).count();
+        tracing::info!(hook_count, "hook executor enabled");
+        for hook in &config.hooks {
+            if hook.is_active() {
+                tracing::info!(
+                    name = ?hook.name,
+                    on_message = ?hook.on_message,
+                    webhook = ?hook.webhook_url,
+                    filter = ?hook.filter_content_type,
+                    "registered hook"
+                );
+            }
+        }
         let mut hook_rx = engine.subscribe();
-        tracing::info!(
-            hook = ?config.hooks.on_message,
-            webhook = ?config.hooks.webhook_url,
-            filter = ?config.hooks.filter_content_type,
-            "hook executor enabled"
-        );
         tokio::spawn(async move {
             while let Ok(msg) = hook_rx.recv().await {
                 executor.execute(&msg).await;


### PR DESCRIPTION
## Summary

Add YAML config file support with multi-hook parallel execution:

- **Config file**: Load from `<data_dir>/config.yaml` with three-layer merge (defaults → YAML → CLI)
- **Multi-hook**: Define multiple named hooks with independent filters and timeouts
- **CLI append**: `--peer` and `--hook-*` flags append to config file entries
- **Validation**: Port conflicts, webhook URL format, hook path existence warnings
- **New flags**: `--config`, `--init-config`, `--gossip-interval-secs`, `--hook-timeout-secs`

Example config:
```yaml
hooks:
  - name: discord-notify
    on_message: ./hooks/discord-notify.sh
    timeout_secs: 10
  - name: insight-webhook
    webhook_url: https://example.com/hooks/egregore
    filter_content_type: insight
```

## Known Issues (for follow-up)

1. Subprocess timeout doesn't kill child process (resource leak risk)
2. No concurrency limit on parallel hooks
3. `serde_yaml` crate is deprecated (consider `serde_yml` fork)

## Test plan

- [x] Build: `cargo build --release`
- [x] Tests: `cargo test`
- [x] Manual: Verify CLI flags still work without config file
- [x] Manual: Verify config file loading and CLI override

🤖 Generated with [Claude Code](https://claude.ai/code)