### PR TITLE
feat: add Docker example for public gossip peer

### DIFF
--- a/example/docker/Dockerfile
+++ b/example/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1-bookworm AS builder
+
+WORKDIR /build
+COPY . .
+RUN cargo build --release -p egregore
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/egregore /usr/local/bin/egregore
+
+VOLUME /data
+
+EXPOSE 7654 7655
+
+ENTRYPOINT ["egregore", "--data-dir", "/data"]

--- a/example/docker/README.md
+++ b/example/docker/README.md
@@ -1,0 +1,68 @@
+# Egregore Docker Deployment
+
+Run an egregore node as a Docker container. Useful as a public-facing gossip peer that bridges external nodes into your mesh without exposing workstation nodes directly.
+
+## Quick Start
+
+```bash
+cd example/docker
+docker compose up -d
+```
+
+The node generates an Ed25519 identity on first run and stores it in the `egregore-data` volume.
+
+## Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 7655 | TCP | Gossip replication (exposed to all interfaces) |
+| 7654 | TCP | HTTP API (localhost only) |
+
+## Configuration
+
+Edit `config.yaml` before starting, or copy it into the data volume:
+
+```bash
+docker compose cp config.yaml egregore:/data/config.yaml
+docker compose restart
+```
+
+Add peers at runtime:
+
+```bash
+curl -X POST http://localhost:7654/v1/peers \
+  -H 'Content-Type: application/json' \
+  -d '{"address": "192.168.1.100:7655"}'
+```
+
+## Management
+
+```bash
+# Check status
+curl http://localhost:7654/v1/status
+
+# View identity
+curl http://localhost:7654/v1/identity
+
+# List peers
+curl http://localhost:7654/v1/peers
+
+# View logs
+docker compose logs -f
+
+# Stop
+docker compose down
+```
+
+## Data Persistence
+
+Identity and database are stored in the `egregore-data` Docker volume. Back up the volume to preserve your node's identity:
+
+```bash
+docker run --rm -v egregore-data:/data -v $(pwd):/backup \
+  busybox tar czf /backup/egregore-backup.tar.gz -C /data .
+```
+
+## Firewall
+
+To accept external peers, forward TCP port 7655 through your firewall/router to the Docker host.

--- a/example/docker/config.yaml
+++ b/example/docker/config.yaml
@@ -1,0 +1,21 @@
+# Egregore Docker Node — Gossip Peer Configuration
+#
+# Minimal config for a public-facing gossip peer.
+# No hooks, no watchers — replication only.
+
+data_dir: /data
+port: 7654
+gossip_port: 7655
+gossip_interval_secs: 300
+network_key: egregore-network-v1
+lan_discovery: false
+discovery_port: 7656
+
+# Add peer addresses for gossip replication.
+# Peers can also be added at runtime via POST /v1/peers.
+# Add your LAN node's address as seen from inside Docker.
+# Find it with: docker inspect egregore --format '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}'
+# Example: <gateway-ip>:7655
+peers: []
+
+hooks: []

--- a/example/docker/docker-compose.yml
+++ b/example/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  egregore:
+    build:
+      context: ../..
+      dockerfile: example/docker/Dockerfile
+    container_name: egregore
+    restart: unless-stopped
+    volumes:
+      - egregore-data:/data
+    ports:
+      # Gossip replication — expose to allow external peers
+      - "7665:7655"
+      # HTTP API — localhost only for management
+      - "127.0.0.1:7664:7654"
+
+volumes:
+  egregore-data:


### PR DESCRIPTION
## Summary

- Adds `example/docker/` with Dockerfile, docker-compose.yml, config, and README
- Multi-stage build (rust builder → debian-slim runtime) for minimal image size
- Designed as a public-facing gossip relay — replication only, no hooks

## Files

| File | Purpose |
|------|---------|
| `example/docker/Dockerfile` | Multi-stage build |
| `example/docker/docker-compose.yml` | Container config with volume + port mapping |
| `example/docker/config.yaml` | Minimal gossip-only config |
| `example/docker/README.md` | Usage, management, and backup instructions |

## Test plan

- [x] `docker compose build` completes successfully
- [x] `docker compose up -d` starts container
- [x] Container generates identity and begins gossip
- [x] Host node discovers container peer and replicates feeds
- [x] `curl localhost:7664/v1/status` returns node status

🤖 Generated with [Claude Code](https://claude.com/claude-code)