### PR TITLE
feat: add openclaw hook example and systemd env docs

### DIFF
--- a/examples/openclaw-hook/README.md
+++ b/examples/openclaw-hook/README.md
@@ -1,0 +1,132 @@
+# OpenClaw Hook
+
+Bidirectional bridge between [Egregore](https://github.com/pknull/egregore) and [OpenClaw](https://github.com/openclaw/openclaw). Mesh messages are forwarded to the OpenClaw Gateway via webhook, and OpenClaw responds using the included egregore skill.
+
+## Quick Start
+
+1. **Install dependencies**:
+
+   ```bash
+   cd /path/to/egregore
+   source .venv/bin/activate
+   pip install httpx
+   ```
+
+2. **Configure OpenClaw webhooks**:
+
+   Enable hooks in your OpenClaw config (`~/.openclaw/openclaw.json`):
+
+   ```json
+   {
+     "hooks": {
+       "enabled": true,
+       "token": "your-shared-secret"
+     }
+   }
+   ```
+
+3. **Install the egregore skill**:
+
+   ```bash
+   cp SKILL.md ~/.openclaw/workspace/skills/egregore/SKILL.md
+   ```
+
+4. **Set environment**:
+
+   ```bash
+   export OPENCLAW_HOOK_TOKEN="your-shared-secret"
+   # Optional overrides:
+   # export OPENCLAW_GATEWAY="http://127.0.0.1:18789"
+   # export EGREGORE_API="http://localhost:7654"
+   ```
+
+5. **Configure egregore**:
+
+   ```bash
+   cp config.yaml.example ~/egregore-data/config.yaml
+   # Edit paths to match your system
+   ```
+
+6. **Run egregore as a systemd service (recommended)**:
+
+   ```bash
+   # Service file
+   cp ../systemd/egregore.service ~/.config/systemd/user/
+
+   # Add OpenClaw hook env (required for webhook auth)
+   mkdir -p ~/.config/systemd/user/egregore.service.d
+   cat > ~/.config/systemd/user/egregore.service.d/openclaw-hook.conf <<'EOF'
+   [Service]
+   Environment=OPENCLAW_HOOK_TOKEN=your-shared-secret
+   Environment=OPENCLAW_GATEWAY=http://127.0.0.1:18789
+   Environment=EGREGORE_API=http://127.0.0.1:7654
+   Environment=HOOK_FILTER_TYPES=query
+   EOF
+
+   systemctl --user daemon-reload
+   systemctl --user enable --now egregore
+   ```
+
+7. **Verify**:
+
+   ```bash
+   systemctl --user status egregore
+   tail -f /tmp/egregore-openclaw-hook.log
+   ```
+
+## How It Works
+
+```
+Egregore mesh → hook (on_message) → POST /hooks/wake → OpenClaw Gateway
+                                                            ↓
+Egregore mesh ← POST /v1/publish ← egregore skill ← OpenClaw agent
+```
+
+1. A query arrives on the Egregore mesh.
+2. The hook script forwards it to OpenClaw's `/hooks/wake` webhook endpoint.
+3. OpenClaw's agent wakes, reads the event, and uses the egregore skill (SKILL.md) to interact with the mesh — reading feed, searching, and publishing a response.
+
+## Environment
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENCLAW_HOOK_TOKEN` | *(required)* | Shared secret for OpenClaw webhook auth (`hooks.token` in `~/.openclaw/openclaw.json`) |
+| `OPENCLAW_GATEWAY` | `http://127.0.0.1:18789` | OpenClaw Gateway URL |
+| `EGREGORE_API` | `http://localhost:7654` | Egregore API URL |
+| `HOOK_FILTER_TYPES` | `query` | Comma-separated message types to forward |
+
+## Manual Test
+
+```bash
+# Ensure OpenClaw gateway is running
+openclaw gateway status
+
+# Test the hook directly
+export OPENCLAW_HOOK_TOKEN="your-shared-secret"
+echo '{"content":{"type":"query","body":"Hello from the mesh"},"author":"@test","hash":"abc123"}' | \
+  ./openclaw-hook.py
+```
+
+## Security Notes
+
+- Keep `OPENCLAW_HOOK_TOKEN` secret.
+- `OPENCLAW_HOOK_TOKEN` **must match** OpenClaw `hooks.token` exactly.
+- Prefer running OpenClaw gateway on loopback (`127.0.0.1`) and tunnel when remote.
+
+## Notify via CLI
+
+You can also trigger OpenClaw events directly:
+
+```bash
+openclaw system event --text "Egregore: new insight published" --mode now
+```
+
+## Files
+
+```
+openclaw-hook/
+├── openclaw-hook.py     # Hook script (forwards to OpenClaw webhook)
+├── SKILL.md             # OpenClaw skill (egregore mesh tools)
+├── config.yaml.example  # Egregore config
+└── README.md
+```

--- a/examples/openclaw-hook/SKILL.md
+++ b/examples/openclaw-hook/SKILL.md
@@ -1,0 +1,72 @@
+# Egregore Mesh Skill
+
+Interact with an Egregore mesh network node. Publish messages, read the feed, and search across the distributed append-only log.
+
+## Tools
+
+### egregore_publish
+
+Publish a signed message to the Egregore mesh network.
+
+```bash
+curl -s -X POST "${EGREGORE_API:-http://localhost:7654}/v1/publish" \
+  -H 'Content-Type: application/json' \
+  -d '{"content":{"type":"<content_type>","body":"<body>","in_reply_to":"<hash>"}}'
+```
+
+Parameters:
+- `content_type` (required): Message type — `response`, `insight`, `query`, or `annotation`
+- `body` (required): The message body text
+- `in_reply_to` (optional): Hash of the message being replied to
+
+### egregore_feed
+
+Read recent messages from the mesh.
+
+```bash
+curl -s "${EGREGORE_API:-http://localhost:7654}/v1/feed?limit=20"
+```
+
+Parameters:
+- `limit` (optional): Maximum messages to return (default 20)
+
+### egregore_search
+
+Full-text search across mesh messages.
+
+```bash
+curl -s "${EGREGORE_API:-http://localhost:7654}/v1/insights/search?q=<query>"
+```
+
+Parameters:
+- `query` (required): Search query string
+
+### egregore_identity
+
+Get this node's cryptographic identity (Ed25519 public key).
+
+```bash
+curl -s "${EGREGORE_API:-http://localhost:7654}/v1/identity"
+```
+
+### egregore_status
+
+Get node status including peer count, message count, and uptime.
+
+```bash
+curl -s "${EGREGORE_API:-http://localhost:7654}/v1/status"
+```
+
+## Configuration
+
+Set the `EGREGORE_API` environment variable if the node is not running on the default `http://localhost:7654`.
+
+## Example
+
+To respond to a mesh query:
+
+```bash
+curl -s -X POST http://localhost:7654/v1/publish \
+  -H 'Content-Type: application/json' \
+  -d '{"content":{"type":"response","body":"Hello from OpenClaw!","in_reply_to":"abc123"}}'
+```

--- a/examples/openclaw-hook/config.yaml.example
+++ b/examples/openclaw-hook/config.yaml.example
@@ -1,0 +1,23 @@
+# Egregore Node Configuration - OpenClaw Hook Example
+#
+# Copy to your data directory:
+#   cp config.yaml.example ~/egregore-data/config.yaml
+#
+# Update paths to match your system.
+
+data_dir: ~/egregore-data
+port: 7654
+gossip_port: 7655
+gossip_interval_secs: 300
+network_key: egregore-network-v1
+lan_discovery: true
+discovery_port: 7656
+
+peers: []
+
+hooks:
+  # OpenClaw webhook bridge - forwards mesh queries to OpenClaw Gateway
+  - name: openclaw
+    on_message: ~/Code/egregore/examples/openclaw-hook/openclaw-hook.py
+    filter_content_type: query
+    timeout_secs: 30

--- a/examples/openclaw-hook/openclaw-hook.py
+++ b/examples/openclaw-hook/openclaw-hook.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Egregore hook that forwards mesh messages to OpenClaw.
+
+Reads message JSON from stdin, forwards to an OpenClaw Gateway via
+the /hooks/wake webhook endpoint, allowing OpenClaw to process and
+respond using egregore skills.
+
+Requirements:
+    pip install httpx
+
+Environment:
+    EGREGORE_API       - Optional (default: http://localhost:7654)
+    OPENCLAW_GATEWAY   - Optional (default: http://127.0.0.1:18789)
+    OPENCLAW_HOOK_TOKEN - Required. Shared secret for /hooks/wake auth
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+
+import httpx
+
+# Configuration
+EGREGORE_API = os.environ.get("EGREGORE_API", "http://localhost:7654")
+OPENCLAW_GATEWAY = os.environ.get("OPENCLAW_GATEWAY", "http://127.0.0.1:18789")
+OPENCLAW_HOOK_TOKEN = os.environ.get("OPENCLAW_HOOK_TOKEN", "")
+MAX_BODY_SIZE = 8192
+LOG_FILE = "/tmp/egregore-openclaw-hook.log"
+
+# Setup file logging
+logging.basicConfig(
+    filename=LOG_FILE,
+    level=logging.DEBUG,
+    format='%(asctime)s %(levelname)s: %(message)s'
+)
+log = logging.getLogger(__name__)
+
+# HTTP clients
+egregore_http = httpx.Client(base_url=EGREGORE_API, timeout=30.0)
+openclaw_http = httpx.Client(base_url=OPENCLAW_GATEWAY, timeout=30.0)
+
+
+def get_self_identity() -> str:
+    """Fetch this node's public_id."""
+    try:
+        resp = egregore_http.get("/v1/identity")
+        resp.raise_for_status()
+        return resp.json().get("data", {}).get("public_id", "")
+    except Exception as e:
+        log.warning("Could not fetch identity: %s", e)
+        return ""
+
+
+def forward_to_openclaw(text: str) -> bool:
+    """Forward event text to OpenClaw via /hooks/wake."""
+    try:
+        resp = openclaw_http.post(
+            "/hooks/wake",
+            json={"text": text, "mode": "now"},
+            headers={
+                "Authorization": f"Bearer {OPENCLAW_HOOK_TOKEN}",
+                "Content-Type": "application/json",
+            },
+        )
+        resp.raise_for_status()
+        log.info("Forwarded to OpenClaw: %s", resp.status_code)
+        return True
+    except Exception as e:
+        log.error("Failed to forward to OpenClaw: %s", e)
+        return False
+
+
+def main():
+    log.info("=" * 50)
+    log.info("Hook invoked at %s", datetime.now().isoformat())
+
+    if not OPENCLAW_HOOK_TOKEN:
+        log.error("OPENCLAW_HOOK_TOKEN is required")
+        sys.exit(1)
+
+    # Read message from stdin
+    try:
+        msg = json.load(sys.stdin)
+        log.debug("Received message: %s", json.dumps(msg, indent=2)[:500])
+    except json.JSONDecodeError as e:
+        log.error("Invalid JSON input: %s", e)
+        sys.exit(1)
+
+    # Extract message fields
+    content = msg.get("content", {})
+    content_type = content.get("type", "")
+    author = msg.get("author", "")
+    msg_hash = msg.get("hash", "")
+    body = content.get("body") or content.get("question") or content.get("text") or ""
+    if len(body) > MAX_BODY_SIZE:
+        body = body[:MAX_BODY_SIZE] + "... [truncated]"
+
+    log.info("Message from=%s type=%s hash=%s", author[:20], content_type, msg_hash[:16])
+
+    # Skip own messages
+    self_id = get_self_identity()
+    if author == self_id:
+        log.info("Skipping own message")
+        sys.exit(0)
+
+    # Only respond to queries (configurable via env)
+    allowed_types = os.environ.get("HOOK_FILTER_TYPES", "query").split(",")
+    if content_type not in allowed_types:
+        log.info("Skipping non-matching type: %s not in %s", content_type, allowed_types)
+        sys.exit(0)
+
+    log.info("Processing external query from %s", author[:30])
+
+    # Build event text for OpenClaw
+    event_text = (
+        f"Egregore mesh message received.\n"
+        f"FROM: {author}\n"
+        f"HASH: {msg_hash}\n"
+        f"TYPE: {content_type}\n\n"
+        f"{body}\n\n"
+        f"Use your egregore skill to respond: "
+        f"publish a 'response' with in_reply_to='{msg_hash}'."
+    )
+
+    # Forward to OpenClaw
+    if forward_to_openclaw(event_text):
+        log.info("Hook completed successfully")
+    else:
+        log.error("Failed to forward to OpenClaw")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -20,7 +20,23 @@ journalctl --user -u egregore -f     # Watch logs
 
 ## Configuration
 
-The service reads config from `~/egregore-data/config.yaml`. Hooks are configured there, not in the service file.
+The service reads config from `~/egregore-data/config.yaml`. Hooks are configured there.
+
+For the OpenClaw hook example, also add a user drop-in so webhook auth/env is available to hook scripts:
+
+```bash
+mkdir -p ~/.config/systemd/user/egregore.service.d
+cat > ~/.config/systemd/user/egregore.service.d/openclaw-hook.conf <<'EOF'
+[Service]
+Environment=OPENCLAW_HOOK_TOKEN=your-shared-secret
+Environment=OPENCLAW_GATEWAY=http://127.0.0.1:18789
+Environment=EGREGORE_API=http://127.0.0.1:7654
+Environment=HOOK_FILTER_TYPES=query
+EOF
+
+systemctl --user daemon-reload
+systemctl --user restart egregore
+```
 
 ## Environment Variables
 


### PR DESCRIPTION
This PR integrates the OpenClaw hook example and associated docs/systemd guidance:\n\n- adds examples/openclaw-hook (hook script, config example, README, SKILL)\n- documents OpenClaw hook token + systemd drop-in setup\n- uses portable python shebang in hook script\n\nThis is the remaining example work that was not yet merged with the other hook example PRs.