### PR TITLE
Add author allowlist support to sample message hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ For nodes on different networks, each must be reachable by the other. Options:
 - **Port forwarding**: Configure router to forward gossip port
 - **VPN**: Use Tailscale, WireGuard, or similar to create a private network
 
+## Hook Author Allowlist (Trust Policy)
+
+The sample hook (`hooks/on-message.sh`) supports an optional author allowlist to restrict which peers can trigger compute.
+
+- Env var: `ALLOWLIST_FILE` (default: `$HOME/.egregore-allowlist`)
+- Format: one author public id per line (e.g. `@...ed25519`)
+- Behavior:
+  - If file exists: only listed authors are processed
+  - If file does not exist: hook keeps current open behavior
+  - Untrusted authors are skipped and logged with a truncated id
+
+Quick start:
+
+```bash
+cp hooks/allowlist.example ~/.egregore-allowlist
+# edit and add trusted author ids, one per line
+```
+
 ## Follow Filtering
 
 With an empty follows list, all feeds are replicated (open replication). Once at least one follow is added, only followed feeds are requested during gossip.

--- a/hooks/allowlist.example
+++ b/hooks/allowlist.example
@@ -1,0 +1,8 @@
+# Trusted Egregore author IDs (one per line)
+# Lines starting with # are comments (remove comments in production files).
+#
+# Point hook at your custom file with:
+#   export ALLOWLIST_FILE=/path/to/allowlist
+#
+# Example:
+# @abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzab5678cdef9012.ed25519

--- a/hooks/on-message.sh
+++ b/hooks/on-message.sh
@@ -18,6 +18,16 @@ if [[ "$AUTHOR" == "$SELF" ]]; then
     exit 0
 fi
 
+# Optional author allowlist (one public_id per line)
+ALLOWLIST_FILE="${ALLOWLIST_FILE:-$HOME/.egregore-allowlist}"
+if [[ -f "$ALLOWLIST_FILE" ]]; then
+    if ! grep -Fxq "$AUTHOR" "$ALLOWLIST_FILE"; then
+        SHORT_AUTHOR="${AUTHOR:0:12}"
+        echo "Skipping untrusted author: ${SHORT_AUTHOR}..." >&2
+        exit 0
+    fi
+fi
+
 # Only respond to queries
 if [[ "$TYPE" != "query" ]]; then
     exit 0


### PR DESCRIPTION
## Summary\n- add optional  check in \n- skip untrusted authors (with truncated author-id logging) when allowlist exists\n- document allowlist behavior in README\n- add  starter file\n\n## Why\nThis implements the trust policy requested in #5 so untrusted mesh authors cannot trigger hook compute when an allowlist is configured.\n\nCloses #5