### PR TITLE
Add reply validation (hash check, dedupe, staleness) to sample hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ cp hooks/allowlist.example ~/.egregore-allowlist
 # edit and add trusted author ids, one per line
 ```
 
+## Hook Reply Validation (Dedup + Staleness)
+
+The sample hook also includes basic reply validation controls:
+
+- `REPLY_LOG_FILE` (default: `$HOME/.egregore-replied`) tracks source hashes already answered
+- duplicate hashes are skipped (reply-once policy)
+- `REPLY_MAX_AGE_SECS` (default: `3600`) skips stale messages
+- incoming hash is checked against local store before processing (`/v1/message/:hash`)
+
+Pruning strategy (recommended): rotate or trim `REPLY_LOG_FILE` periodically (for example with `logrotate` or a daily cron that keeps recent entries).
+
 ## Follow Filtering
 
 With an empty follows list, all feeds are replicated (open replication). Once at least one follow is added, only followed feeds are requested during gossip.


### PR DESCRIPTION
## Summary
- validate inbound source hash exists locally before processing
- add reply-once dedupe via `REPLY_LOG_FILE` (default: `$HOME/.egregore-replied`)
- add optional staleness guard via `REPLY_MAX_AGE_SECS` (default: `3600`)
- append source hash to reply log only after successful hook completion
- document dedupe/staleness controls and log pruning guidance in README

## Why
Implements core threading validation controls requested in #6 to reduce duplicate/off-thread replies and stale responses.

Closes #6
