### PR TITLE
refactor: remove daemon-level hook filtering

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -491,7 +491,7 @@ Each event is a JSON message object. Clients that fall behind receive a `lagged`
 Spawn a subprocess when messages arrive. The message JSON is passed on stdin. Configure via CLI flags:
 
 ```bash
-egregore --hook-on-message ~/.egregore/hooks/respond.sh --hook-filter-type query
+egregore --hook-on-message ~/.egregore/hooks/respond.sh
 ```
 
 The hook script can implement any integration — call an LLM, post to a webhook, trigger a Slack bot, etc. Example:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -36,7 +36,6 @@ cargo run -- --data-dir ./data
 | `--discovery-port` | `7656` | UDP port for LAN discovery announcements |
 | `--hook-on-message` | none | Path to script called when messages arrive |
 | `--hook-webhook-url` | none | URL to POST message JSON when messages arrive |
-| `--hook-filter-type` | none | Only trigger hooks for this content type (e.g., "query") |
 
 ### Verify
 
@@ -312,8 +311,7 @@ Spawn a subprocess when messages arrive. Configure via CLI:
 
 ```bash
 cargo run -- --data-dir ./data \
-  --hook-on-message ~/.egregore/hooks/respond.sh \
-  --hook-filter-type query
+  --hook-on-message ~/.egregore/hooks/respond.sh
 ```
 
 The hook receives message JSON on stdin:
@@ -328,8 +326,7 @@ POST message JSON directly to a URL when messages arrive:
 
 ```bash
 cargo run -- --data-dir ./data \
-  --hook-webhook-url https://hooks.slack.com/services/T.../B.../xxx \
-  --hook-filter-type query
+  --hook-webhook-url https://hooks.slack.com/services/T.../B.../xxx
 ```
 
 Both hook types can be used simultaneously — subprocess for local processing, webhook for remote notification:
@@ -337,8 +334,7 @@ Both hook types can be used simultaneously — subprocess for local processing, 
 ```bash
 cargo run -- --data-dir ./data \
   --hook-on-message ~/.egregore/hooks/log.sh \
-  --hook-webhook-url https://my-service.example.com/egregore-events \
-  --hook-filter-type insight
+  --hook-webhook-url https://my-service.example.com/egregore-events
 ```
 
 The webhook POSTs the full message JSON with `Content-Type: application/json`.

--- a/examples/claude-hook/config.yaml.example
+++ b/examples/claude-hook/config.yaml.example
@@ -19,5 +19,4 @@ hooks:
   # Claude Agent SDK hook - uses Claude Code credentials
   - name: claude-agent
     on_message: ~/Code/egregore/examples/claude-hook/claude-agent-hook.py
-    filter_content_type: query
     timeout_secs: 120

--- a/examples/ollama-hook/config.yaml.example
+++ b/examples/ollama-hook/config.yaml.example
@@ -18,5 +18,4 @@ peers: []
 hooks:
   - name: ollama
     on_message: ~/Code/egregore/examples/ollama-hook/ollama-hook.py
-    filter_content_type: query
     timeout_secs: 60

--- a/examples/openai-hook/config.yaml.example
+++ b/examples/openai-hook/config.yaml.example
@@ -19,11 +19,9 @@ hooks:
   # Codex CLI hook - uses ChatGPT account credentials (no API key)
   - name: codex
     on_message: ~/Code/egregore/examples/openai-hook/codex-hook.py
-    filter_content_type: query
     timeout_secs: 120
 
   # Uncomment to use OpenAI API directly (requires OPENAI_API_KEY)
   # - name: openai
   #   on_message: ~/Code/egregore/examples/openai-hook/openai-hook.py
-  #   filter_content_type: query
   #   timeout_secs: 60

--- a/examples/openclaw-hook/config.yaml.example
+++ b/examples/openclaw-hook/config.yaml.example
@@ -19,5 +19,4 @@ hooks:
   # OpenClaw webhook bridge - forwards mesh queries to OpenClaw Gateway
   - name: openclaw
     on_message: ~/Code/egregore/examples/openclaw-hook/openclaw-hook.py
-    filter_content_type: query
     timeout_secs: 30

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,9 +19,6 @@ pub struct HookEntry {
     pub on_message: Option<PathBuf>,
     /// URL to POST message JSON to when a message arrives.
     pub webhook_url: Option<String>,
-    /// Optional content type filter (e.g., "query", "insight").
-    /// If set, hook only fires for messages matching this type.
-    pub filter_content_type: Option<String>,
     /// Timeout in seconds for hook/webhook execution (default: 30).
     pub timeout_secs: Option<u64>,
 }
@@ -212,7 +209,6 @@ mod tests {
                 HookEntry {
                     name: Some("test-hook".to_string()),
                     on_message: Some(PathBuf::from("./hooks/test.sh")),
-                    filter_content_type: Some("insight".to_string()),
                     timeout_secs: Some(10),
                     ..Default::default()
                 },

--- a/src/config_template.yaml
+++ b/src/config_template.yaml
@@ -43,7 +43,7 @@ discovery_port: 7656
 peers: []
 
 # Hook definitions. Each hook fires independently on message events.
-# Hooks run in parallel. Each can have its own filter and timeout.
+# Hooks run in parallel. Each can have its own timeout.
 # CLI --hook-on-message/--hook-webhook-url append an additional hook.
 #
 # Example:
@@ -53,7 +53,6 @@ peers: []
 #     timeout_secs: 10
 #   - name: insight-webhook
 #     webhook_url: https://example.com/hooks/egregore
-#     filter_content_type: insight
 #     timeout_secs: 15
 #   - name: full-pipeline
 #     on_message: ./hooks/process.sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,10 +73,6 @@ struct Cli {
     #[arg(long)]
     hook_webhook_url: Option<String>,
 
-    /// Filter hooks to specific content type (e.g., "query")
-    #[arg(long)]
-    hook_filter_type: Option<String>,
-
     /// Hook timeout in seconds
     #[arg(long)]
     hook_timeout_secs: Option<u64>,
@@ -146,7 +142,6 @@ fn build_config(cli: &Cli, matches: &clap::ArgMatches) -> anyhow::Result<Config>
         name: Some("cli".to_string()),
         on_message: cli.hook_on_message.clone(),
         webhook_url: cli.hook_webhook_url.clone(),
-        filter_content_type: cli.hook_filter_type.clone(),
         timeout_secs: cli.hook_timeout_secs,
     };
     if cli_hook.is_active() {
@@ -220,7 +215,6 @@ async fn main() -> anyhow::Result<()> {
                     name = ?hook.name,
                     on_message = ?hook.on_message,
                     webhook = ?hook.webhook_url,
-                    filter = ?hook.filter_content_type,
                     "registered hook"
                 );
             }


### PR DESCRIPTION
## Summary

Removes `filter_content_type` from egregore daemon. Hook scripts control their own filtering via `HOOK_FILTER_TYPES` env var.

## Philosophy

Egregore passes all messages to hooks. Filtering logic belongs in the hook script itself, not the daemon.

## Changes

- Remove `filter_content_type` from `HookEntry` struct
- Remove `--hook-filter-type` CLI flag  
- Remove filter logic from `HookExecutor`
- Update docs and example configs

## Test plan

- [x] `cargo check` passes
- [ ] Manual: hook receives all message types

🤖 Generated with [Claude Code](https://claude.com/claude-code)