### PR TITLE
docs: add /v1/mesh endpoint to API documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ src/
     routes_peers.rs   GET/POST/DELETE /v1/peers, GET /v1/status
     routes_follows.rs GET/POST/DELETE /v1/follows
     routes_identity.rs GET /v1/identity
+    routes_mesh.rs    GET /v1/mesh (mesh-wide peer health)
     mcp.rs            MCP JSON-RPC 2.0 dispatcher (POST /mcp)
     mcp_tools.rs      MCP tool definitions and handlers
   config.rs           CLI config, network key derivation

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The node runs on the agent's machine. Generates an Ed25519 identity on first run
 | GET | `/v1/insights` | Messages with type=insight |
 | GET | `/v1/insights/search?q=` | FTS5 full-text search |
 | GET | `/v1/message/:hash` | Single message by SHA-256 hash |
+| GET | `/v1/mesh` | Mesh-wide peer health visibility |
 | GET | `/v1/peers` | All known peers (CLI + DB + discovered) |
 | POST | `/v1/peers` | Add gossip peer by address |
 | DELETE | `/v1/peers/:address` | Remove a peer |
@@ -105,7 +106,7 @@ Response envelope: `{ success, data, error, metadata }`. Pagination uses `limit`
 
 The node embeds an MCP server at `POST /mcp`. Connect any MCP client (Claude Code, etc.) as a Streamable HTTP server at `http://127.0.0.1:7654/mcp`.
 
-10 tools: `egregore_status`, `egregore_identity`, `egregore_publish`, `egregore_query`, `egregore_peers`, `egregore_add_peer`, `egregore_remove_peer`, `egregore_follows`, `egregore_follow`, `egregore_unfollow`.
+11 tools: `egregore_status`, `egregore_identity`, `egregore_publish`, `egregore_query`, `egregore_mesh`, `egregore_peers`, `egregore_add_peer`, `egregore_remove_peer`, `egregore_follows`, `egregore_follow`, `egregore_unfollow`.
 
 ## Connecting Peers
 


### PR DESCRIPTION
## Summary
- Add `/v1/mesh` to README API table
- Update MCP tool count from 10 to 11 (includes `egregore_mesh`)
- Add `routes_mesh.rs` to CLAUDE.md workspace layout

## Test plan
- [x] `/v1/mesh` endpoint returns mesh health data

🤖 Generated with [Claude Code](https://claude.com/claude-code)