### PR TITLE
chore: resolve clippy warnings and bump to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "egregore"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name = "egregore"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "SSB-inspired decentralized knowledge sharing for LLMs"
 license = "MIT"

--- a/src/crypto/handshake.rs
+++ b/src/crypto/handshake.rs
@@ -139,7 +139,6 @@ impl ClientHandshake {
 
         let state = ClientHandshakeStep3 {
             network_key: self.network_key,
-            identity: self.identity,
             client_eph_pk: self.ephemeral_public,
             server_eph_pk,
             shared_ab,
@@ -153,7 +152,6 @@ impl ClientHandshake {
 /// Client state after step 3, waiting for server's step 4 response.
 pub struct ClientHandshakeStep3 {
     network_key: [u8; 32],
-    identity: Identity,
     client_eph_pk: X25519Public,
     server_eph_pk: X25519Public,
     shared_ab: SharedSecret,

--- a/src/crypto/private_box.rs
+++ b/src/crypto/private_box.rs
@@ -14,7 +14,7 @@
 use chacha20poly1305::aead::{Aead, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use rand::RngCore;
-use x25519_dalek::{PublicKey as X25519Public, StaticSecret};
+use x25519_dalek::PublicKey as X25519Public;
 
 use crate::error::{EgreError, Result};
 use crate::identity::Identity;

--- a/src/gossip/connection.rs
+++ b/src/gossip/connection.rs
@@ -150,7 +150,7 @@ impl SecureConnection {
         }
 
         // Calculate total chunks without intermediate allocation
-        let total_chunks = (data.len() + Self::MAX_CHUNK_SIZE - 1) / Self::MAX_CHUNK_SIZE;
+        let total_chunks = data.len().div_ceil(Self::MAX_CHUNK_SIZE);
 
         for (i, chunk) in data.chunks(Self::MAX_CHUNK_SIZE).enumerate() {
             let is_final = i == total_chunks - 1;

--- a/src/gossip/health.rs
+++ b/src/gossip/health.rs
@@ -42,8 +42,10 @@ pub struct PeerObservation {
 }
 
 /// Clamp an observation timestamp to a valid range.
+///
 /// - Not in the future (clock skew protection)
 /// - Not older than MAX_OBSERVATION_AGE_HOURS (stale data protection)
+///
 /// Returns None if the timestamp is too old to be useful.
 pub fn clamp_observation_timestamp(ts: DateTime<Utc>) -> Option<DateTime<Utc>> {
     let now = Utc::now();

--- a/src/identity/keys.rs
+++ b/src/identity/keys.rs
@@ -125,7 +125,7 @@ impl PublicId {
             return false;
         }
         let b64_part = &s[1..45];
-        B64.decode(b64_part).map_or(false, |bytes| bytes.len() == 32)
+        B64.decode(b64_part).is_ok_and(|bytes| bytes.len() == 32)
     }
 
     /// Create from a verifying (public) key.


### PR DESCRIPTION
## Summary

- Remove unused `StaticSecret` import in private_box.rs
- Remove dead `identity` field from `ClientHandshakeStep3` struct
- Use `div_ceil()` instead of manual ceiling division
- Fix doc comment formatting in health.rs
- Use `is_ok_and()` instead of `map_or(false, ...)`
- Bump version to 0.2.1

## Test plan

- [x] `cargo clippy` reports no warnings
- [x] `cargo test` passes (10/10 integration tests)
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)