### PR TITLE
feat: add relates and tags envelope fields (v0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -223,6 +225,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,10 +264,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -499,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "egregore"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -515,6 +544,7 @@ dependencies = [
  "futures",
  "hmac",
  "http-body-util",
+ "jsonschema",
  "rand",
  "reqwest",
  "rpassword",
@@ -533,6 +563,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "x25519-dalek",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -573,6 +612,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +639,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
 
 [[package]]
 name = "fnv"
@@ -624,6 +685,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -734,6 +805,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -1133,6 +1216,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161c33c3ec738cfea3288c5c53dfcdb32fd4fc2954de86ea06f71b5a1a40bfcd"
+dependencies = [
+ "ahash",
+ "base64",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1361,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1500,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -1514,6 +1698,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a64b3a635fad9000648b4d8a59c8710c523ab61a23d392a7d91d47683f5adc"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1757,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2301,6 +2521,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2558,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name = "egregore"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "SSB-inspired decentralized knowledge sharing for LLMs"
 license = "MIT"
@@ -67,6 +67,9 @@ rand = "0.8"
 
 # Bytes
 bytes = "1.0"
+
+# JSON Schema validation
+jsonschema = "0.29"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/api/mcp_registry.rs
+++ b/src/api/mcp_registry.rs
@@ -1,0 +1,173 @@
+//! MCP Tool Registry with JSON Schema validation.
+//!
+//! Compiles input schemas at startup for O(1) validation. Provides detailed
+//! error messages when inputs fail validation.
+
+use jsonschema::Validator;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::mcp_tools::{tool_definitions, ToolDefinition};
+
+/// Compiled tool registry with pre-built schema validators.
+pub struct ToolRegistry {
+    tools: HashMap<&'static str, RegisteredTool>,
+}
+
+struct RegisteredTool {
+    definition: ToolDefinition,
+    validator: Validator,
+}
+
+/// Tool validation error with context.
+#[derive(Debug)]
+pub struct ToolValidationError {
+    #[allow(dead_code)]
+    pub tool: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for ToolValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ToolValidationError {}
+
+impl ToolRegistry {
+    /// Build registry, compiling all tool schemas.
+    pub fn new() -> Self {
+        let definitions = tool_definitions();
+        let mut tools = HashMap::with_capacity(definitions.len());
+
+        for def in definitions {
+            let validator = jsonschema::validator_for(&def.input_schema)
+                .expect("tool schema must be valid JSON Schema");
+
+            tools.insert(
+                def.name,
+                RegisteredTool {
+                    definition: def,
+                    validator,
+                },
+            );
+        }
+
+        Self { tools }
+    }
+
+    /// Get tool definition by name.
+    #[allow(dead_code)]
+    pub fn get(&self, name: &str) -> Option<&ToolDefinition> {
+        self.tools.get(name).map(|t| &t.definition)
+    }
+
+    /// List all tool definitions.
+    pub fn list(&self) -> Vec<&ToolDefinition> {
+        self.tools.values().map(|t| &t.definition).collect()
+    }
+
+    /// Validate arguments against tool's input schema.
+    /// Returns Ok(()) if valid, Err with detailed message if not.
+    pub fn validate(&self, name: &str, args: &Value) -> Result<(), ToolValidationError> {
+        let tool = self.tools.get(name).ok_or_else(|| ToolValidationError {
+            tool: name.to_string(),
+            message: format!("Unknown tool: {name}"),
+        })?;
+
+        let errors: Vec<String> = tool
+            .validator
+            .iter_errors(args)
+            .map(|e| {
+                let path = e.instance_path.to_string();
+                let path_str = if path.is_empty() { "root" } else { &path };
+                format!("{}: {}", path_str, e)
+            })
+            .collect();
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ToolValidationError {
+                tool: name.to_string(),
+                message: errors.join("; "),
+            })
+        }
+    }
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Thread-safe registry handle.
+pub type SharedRegistry = Arc<ToolRegistry>;
+
+pub fn create_registry() -> SharedRegistry {
+    Arc::new(ToolRegistry::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_registry() {
+        let registry = ToolRegistry::new();
+        assert!(registry.get("egregore_status").is_some());
+        assert!(registry.get("egregore_publish").is_some());
+        assert!(registry.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn validates_required_fields() {
+        let registry = ToolRegistry::new();
+
+        // publish requires content
+        let result = registry.validate("egregore_publish", &serde_json::json!({}));
+        assert!(result.is_err());
+
+        let result = registry.validate(
+            "egregore_publish",
+            &serde_json::json!({ "content": { "type": "test" } }),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validates_type_constraints() {
+        let registry = ToolRegistry::new();
+
+        // limit must be integer
+        let result = registry.validate(
+            "egregore_query",
+            &serde_json::json!({ "limit": "not a number" }),
+        );
+        assert!(result.is_err());
+
+        let result = registry.validate("egregore_query", &serde_json::json!({ "limit": 10 }));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn empty_args_valid_for_no_required() {
+        let registry = ToolRegistry::new();
+
+        // status has no required fields
+        let result = registry.validate("egregore_status", &serde_json::json!({}));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn error_message_includes_path() {
+        let registry = ToolRegistry::new();
+
+        let result = registry.validate("egregore_publish", &serde_json::json!({}));
+        let err = result.unwrap_err();
+        assert!(err.message.contains("content"), "Should mention missing field");
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,7 @@
 //! the MCP JSON-RPC 2.0 endpoint at POST /mcp, and SSE streaming at GET /v1/events.
 
 pub mod mcp;
+pub mod mcp_registry;
 pub mod mcp_tools;
 pub mod response;
 pub mod routes_events;
@@ -29,12 +30,15 @@ use egregore::config::Config;
 use egregore::feed::engine::FeedEngine;
 use egregore::identity::Identity;
 
+use mcp_registry::SharedRegistry;
+
 #[derive(Clone)]
 pub struct AppState {
     pub identity: Identity,
     pub engine: Arc<FeedEngine>,
     pub config: Arc<Config>,
     pub started_at: Instant,
+    pub mcp_registry: SharedRegistry,
 }
 
 pub fn router(state: AppState) -> Router {

--- a/src/api/routes_feed.rs
+++ b/src/api/routes_feed.rs
@@ -21,6 +21,10 @@ pub struct FeedParams {
     pub limit: Option<u32>,
     pub offset: Option<u32>,
     pub content_type: Option<String>,
+    /// Filter by tag.
+    pub tag: Option<String>,
+    /// Filter by related message hash (find replies/responses).
+    pub relates: Option<String>,
     /// Include own messages in results (default: false).
     pub include_self: Option<bool>,
 }
@@ -44,6 +48,8 @@ pub async fn get_feed(
             author: None,
             exclude_author: if include_self { None } else { Some(self_id) },
             content_type: params.content_type,
+            tag: params.tag,
+            relates: params.relates,
             limit: params.limit,
             offset: params.offset,
             ..Default::default()

--- a/src/api/routes_publish.rs
+++ b/src/api/routes_publish.rs
@@ -16,6 +16,12 @@ use crate::api::AppState;
 #[derive(Deserialize)]
 pub struct PublishRequest {
     pub content: serde_json::Value,
+    /// Hash of a related message (optional, for threading).
+    #[serde(default)]
+    pub relates: Option<String>,
+    /// Categorization tags (optional).
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 pub async fn publish(
@@ -25,11 +31,12 @@ pub async fn publish(
     let identity = state.identity.clone();
     let engine = state.engine.clone();
 
-    let result = tokio::task::spawn_blocking(move || engine.publish(&identity, req.content))
-        .await
-        .map_err(|e| egregore::error::EgreError::Config {
-            reason: format!("task join error: {e}"),
-        });
+    let result =
+        tokio::task::spawn_blocking(move || engine.publish(&identity, req.content, req.relates, req.tags))
+            .await
+            .map_err(|e| egregore::error::EgreError::Config {
+                reason: format!("task join error: {e}"),
+            });
 
     match result {
         Ok(Ok(msg)) => (StatusCode::CREATED, response::ok(msg)).into_response(),

--- a/src/feed/models.rs
+++ b/src/feed/models.rs
@@ -26,6 +26,12 @@ pub struct Message {
     pub previous: Option<String>,
     pub timestamp: DateTime<Utc>,
     pub content: serde_json::Value,
+    /// Hash of a related message (optional, for threading).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relates: Option<String>,
+    /// Categorization tags (optional).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
     /// SHA-256 hex of canonical JSON (excluding hash + signature).
     pub hash: String,
     /// Ed25519 signature of hash bytes (base64).
@@ -40,6 +46,12 @@ pub struct UnsignedMessage {
     pub previous: Option<String>,
     pub timestamp: DateTime<Utc>,
     pub content: serde_json::Value,
+    /// Hash of a related message (optional, for threading).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relates: Option<String>,
+    /// Categorization tags (optional).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 impl UnsignedMessage {
@@ -70,7 +82,10 @@ pub struct FeedQuery {
     /// Exclude messages from this author (used for "others only" queries).
     pub exclude_author: Option<PublicId>,
     pub content_type: Option<String>,
+    /// Filter by tag (messages must have this tag).
     pub tag: Option<String>,
+    /// Filter by relates hash (messages that reference this hash).
+    pub relates: Option<String>,
     pub limit: Option<u32>,
     pub offset: Option<u32>,
     pub search: Option<String>,
@@ -121,6 +136,8 @@ mod tests {
                 .unwrap()
                 .with_timezone(&Utc),
             content: from_enum,
+            relates: None,
+            tags: vec![],
         };
         let msg_json = UnsignedMessage {
             author: PublicId("@test.ed25519".to_string()),
@@ -130,6 +147,8 @@ mod tests {
                 .unwrap()
                 .with_timezone(&Utc),
             content: from_json,
+            relates: None,
+            tags: vec![],
         };
         assert_eq!(msg_enum.compute_hash(), msg_json.compute_hash());
     }
@@ -149,6 +168,8 @@ mod tests {
                 "description": null,
                 "capabilities": [],
             }),
+            relates: None,
+            tags: vec![],
         };
         let h1 = msg.compute_hash();
         let h2 = msg.compute_hash();

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -161,24 +161,7 @@ impl HookExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::identity::PublicId;
-    use chrono::Utc;
     use std::path::PathBuf;
-
-    fn make_test_message(content_type: &str) -> Message {
-        Message {
-            author: PublicId("@test.ed25519".to_string()),
-            sequence: 1,
-            previous: None,
-            timestamp: Utc::now(),
-            content: serde_json::json!({
-                "type": content_type,
-                "data": "test"
-            }),
-            hash: "testhash".to_string(),
-            signature: "testsig".to_string(),
-        }
-    }
 
     #[test]
     fn executor_returns_none_without_hooks() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,7 @@ async fn main() -> anyhow::Result<()> {
         engine: engine.clone(),
         config: Arc::new(config.clone()),
         started_at: std::time::Instant::now(),
+        mcp_registry: api::mcp_registry::create_registry(),
     };
     let app = api::router(state);
 

--- a/tests/gossip_test.rs
+++ b/tests/gossip_test.rs
@@ -35,7 +35,7 @@ async fn two_instance_gossip_replication() {
     let engine_a = Arc::new(FeedEngine::new(store_a));
 
     engine_a
-        .publish(&identity_a, test_content("Test insight"))
+        .publish(&identity_a, test_content("Test insight"), None, vec![])
         .unwrap();
 
     // Verify A has 1 message
@@ -128,14 +128,14 @@ async fn bidirectional_replication() {
     // A publishes 2 messages
     for i in 0..2 {
         engine_a
-            .publish(&identity_a, test_content(&format!("A-insight-{i}")))
+            .publish(&identity_a, test_content(&format!("A-insight-{i}")), None, vec![])
             .unwrap();
     }
 
     // B publishes 3 messages
     for i in 0..3 {
         engine_b
-            .publish(&identity_b, test_content(&format!("B-insight-{i}")))
+            .publish(&identity_b, test_content(&format!("B-insight-{i}")), None, vec![])
             .unwrap();
     }
 
@@ -213,10 +213,10 @@ async fn follow_filtered_replication() {
 
     // A has feeds X and Y
     engine_a
-        .publish(&identity_x, test_content("X-insight"))
+        .publish(&identity_x, test_content("X-insight"), None, vec![])
         .unwrap();
     engine_a
-        .publish(&identity_y, test_content("Y-insight"))
+        .publish(&identity_y, test_content("Y-insight"), None, vec![])
         .unwrap();
 
     assert_eq!(engine_a.store().get_all_feeds().unwrap().len(), 2);


### PR DESCRIPTION
## Summary

- Adds `relates: Option<String>` to message envelope for threading (hash reference to related message)
- Adds `tags: Vec<String>` for categorization labels
- Implements MCP tool parameter validation using JSON Schema (`jsonschema` crate)
- Bumps version to 0.3.0

Both new fields are optional and backwards compatible—existing messages without them parse correctly.

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Protocol | `src/feed/models.rs` | New envelope fields in Message/UnsignedMessage |
| Storage | `src/feed/store/*.rs` | Schema migration, tag normalization table |
| Engine | `src/feed/engine.rs` | Updated publish signature, hash computation |
| API | `src/api/routes_*.rs` | Query param support for tag/relates filtering |
| MCP | `src/api/mcp*.rs` | Schema validation registry, updated tool params |
| Tests | `tests/*.rs` | All fixtures updated for new fields |

## Test plan

- [x] All 89 unit tests pass
- [x] All 10 integration tests pass
- [x] Clippy clean
- [x] Release build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)