### PR TITLE
feat: push-based replication for real-time message propagation (v0.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +472,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -528,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "egregore"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -540,6 +560,7 @@ dependencies = [
  "chrono",
  "clap",
  "curve25519-dalek",
+ "dashmap",
  "ed25519-dalek",
  "futures",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name = "egregore"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "SSB-inspired decentralized knowledge sharing for LLMs"
 license = "MIT"
@@ -70,6 +70,9 @@ bytes = "1.0"
 
 # JSON Schema validation
 jsonschema = "0.29"
+
+# Concurrent hashmap for connection registry
+dashmap = "6.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,32 @@ pub struct Config {
     /// Multiple hook configurations for event-driven handlers.
     #[serde(default)]
     pub hooks: Vec<HookEntry>,
+    /// Enable persistent push-based connections.
+    /// When enabled, after initial replication, connections attempt to
+    /// negotiate persistent mode for real-time message propagation.
+    #[serde(default)]
+    pub push_enabled: bool,
+    /// Maximum number of persistent connections to maintain.
+    #[serde(default = "default_max_persistent_connections")]
+    pub max_persistent_connections: usize,
+    /// Initial delay for reconnection attempts (in seconds).
+    #[serde(default = "default_reconnect_initial_secs")]
+    pub reconnect_initial_secs: u64,
+    /// Maximum delay for reconnection attempts (in seconds).
+    #[serde(default = "default_reconnect_max_secs")]
+    pub reconnect_max_secs: u64,
+}
+
+fn default_max_persistent_connections() -> usize {
+    32
+}
+
+fn default_reconnect_initial_secs() -> u64 {
+    5
+}
+
+fn default_reconnect_max_secs() -> u64 {
+    300
 }
 
 impl Default for Config {
@@ -57,6 +83,10 @@ impl Default for Config {
             lan_discovery: false,
             discovery_port: 7656,
             hooks: Vec::new(),
+            push_enabled: false,
+            max_persistent_connections: default_max_persistent_connections(),
+            reconnect_initial_secs: default_reconnect_initial_secs(),
+            reconnect_max_secs: default_reconnect_max_secs(),
         }
     }
 }

--- a/src/config_template.yaml
+++ b/src/config_template.yaml
@@ -59,3 +59,25 @@ peers: []
 #     webhook_url: https://example.com/hooks/backup
 #     timeout_secs: 30
 hooks: []
+
+# Push-based replication settings.
+# When enabled, connections attempt to negotiate persistent mode for
+# real-time message propagation (in addition to periodic pull sync).
+
+# Enable persistent push connections.
+# Default: false
+push_enabled: false
+
+# Maximum number of persistent connections to maintain.
+# Applies to both incoming and outgoing persistent connections.
+# Default: 32
+max_persistent_connections: 32
+
+# Initial delay for reconnection attempts (in seconds).
+# Uses exponential backoff with jitter.
+# Default: 5
+reconnect_initial_secs: 5
+
+# Maximum delay for reconnection attempts (in seconds).
+# Default: 300 (5 minutes)
+reconnect_max_secs: 300

--- a/src/gossip/backoff.rs
+++ b/src/gossip/backoff.rs
@@ -1,0 +1,176 @@
+//! Exponential backoff with jitter for reconnection attempts.
+//!
+//! Implements truncated binary exponential backoff as used in TCP and
+//! distributed systems. Jitter prevents thundering herd when multiple
+//! clients reconnect simultaneously.
+
+use std::time::Duration;
+
+use rand::Rng;
+
+/// Exponential backoff calculator with jitter.
+///
+/// Starts at `initial_delay` and doubles on each failure up to `max_delay`.
+/// Full jitter is applied: actual delay is uniform random in [0, calculated_delay].
+#[derive(Debug, Clone)]
+pub struct ExponentialBackoff {
+    /// Initial delay on first retry.
+    initial_delay: Duration,
+    /// Maximum delay cap.
+    max_delay: Duration,
+    /// Current attempt number (0 = first attempt, 1 = first retry).
+    attempt: u32,
+    /// Maximum exponent to prevent overflow.
+    max_exponent: u32,
+}
+
+impl ExponentialBackoff {
+    /// Create a new backoff calculator.
+    ///
+    /// # Arguments
+    /// * `initial_delay` - Delay for the first retry (default: 5 seconds)
+    /// * `max_delay` - Maximum delay cap (default: 5 minutes)
+    pub fn new(initial_delay: Duration, max_delay: Duration) -> Self {
+        // Calculate max exponent to prevent overflow
+        // 2^max_exp * initial_millis <= max_millis
+        let initial_millis = initial_delay.as_millis() as u64;
+        let max_millis = max_delay.as_millis() as u64;
+        let max_exponent = if initial_millis > 0 {
+            ((max_millis / initial_millis) as f64).log2().floor() as u32
+        } else {
+            0
+        };
+
+        Self {
+            initial_delay,
+            max_delay,
+            attempt: 0,
+            max_exponent: max_exponent.min(20), // Cap at 2^20 to be safe
+        }
+    }
+
+    /// Create with default values (5s initial, 5 min max).
+    pub fn default_reconnect() -> Self {
+        Self::new(Duration::from_secs(5), Duration::from_secs(300))
+    }
+
+    /// Get the next delay and increment the attempt counter.
+    ///
+    /// Returns a duration with full jitter applied.
+    pub fn next_delay(&mut self) -> Duration {
+        let delay = self.calculate_delay();
+        self.attempt = self.attempt.saturating_add(1);
+        delay
+    }
+
+    /// Calculate the delay for the current attempt without incrementing.
+    pub fn calculate_delay(&self) -> Duration {
+        let exp = self.attempt.min(self.max_exponent);
+        let multiplier = 1u64 << exp; // 2^exp
+        let base_millis = self.initial_delay.as_millis() as u64;
+        let calculated_millis = base_millis.saturating_mul(multiplier);
+
+        // Cap at max delay
+        let capped_millis = calculated_millis.min(self.max_delay.as_millis() as u64);
+
+        // Apply full jitter: uniform random in [0, capped_delay]
+        let jittered = if capped_millis > 0 {
+            rand::thread_rng().gen_range(0..=capped_millis)
+        } else {
+            0
+        };
+
+        Duration::from_millis(jittered)
+    }
+
+    /// Reset the backoff counter (call after successful connection).
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    /// Get the current attempt number.
+    pub fn attempt(&self) -> u32 {
+        self.attempt
+    }
+
+    /// Check if we've exceeded a reasonable retry limit (for logging).
+    pub fn is_extended(&self) -> bool {
+        self.attempt >= 5
+    }
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        Self::default_reconnect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_starts_at_initial() {
+        let backoff = ExponentialBackoff::new(Duration::from_secs(5), Duration::from_secs(300));
+        // First delay should be in [0, 5s]
+        let delay = backoff.calculate_delay();
+        assert!(delay <= Duration::from_secs(5));
+    }
+
+    #[test]
+    fn backoff_doubles() {
+        let mut backoff = ExponentialBackoff::new(Duration::from_secs(1), Duration::from_secs(60));
+
+        // Skip first attempt (1s max)
+        let _ = backoff.next_delay();
+
+        // Second attempt should have max of 2s
+        // We can't test exact values due to jitter, but we can check the range
+        assert_eq!(backoff.attempt, 1);
+
+        let _ = backoff.next_delay();
+        assert_eq!(backoff.attempt, 2);
+    }
+
+    #[test]
+    fn backoff_caps_at_max() {
+        let mut backoff = ExponentialBackoff::new(Duration::from_secs(5), Duration::from_secs(30));
+
+        // After many attempts, should still be capped
+        for _ in 0..100 {
+            let delay = backoff.next_delay();
+            assert!(delay <= Duration::from_secs(30));
+        }
+    }
+
+    #[test]
+    fn backoff_resets() {
+        let mut backoff = ExponentialBackoff::new(Duration::from_secs(5), Duration::from_secs(300));
+
+        for _ in 0..5 {
+            let _ = backoff.next_delay();
+        }
+        assert_eq!(backoff.attempt, 5);
+
+        backoff.reset();
+        assert_eq!(backoff.attempt, 0);
+    }
+
+    #[test]
+    fn backoff_handles_zero_initial() {
+        let backoff = ExponentialBackoff::new(Duration::from_secs(0), Duration::from_secs(60));
+        let delay = backoff.calculate_delay();
+        assert_eq!(delay, Duration::from_secs(0));
+    }
+
+    #[test]
+    fn is_extended_after_five_attempts() {
+        let mut backoff = ExponentialBackoff::default();
+        assert!(!backoff.is_extended());
+
+        for _ in 0..5 {
+            let _ = backoff.next_delay();
+        }
+        assert!(backoff.is_extended());
+    }
+}

--- a/src/gossip/client.rs
+++ b/src/gossip/client.rs
@@ -8,22 +8,76 @@
 //! Per-peer sync: TCP connect → SHS handshake → bidirectional replication → close.
 //! The replication protocol (Have/Want/Messages/Done) runs over Box Stream.
 //! See gossip/replication.rs for the wire protocol.
+//!
+//! With push_enabled: After replication, negotiate persistent mode. If accepted,
+//! split the connection and register for push-based message broadcasting.
+//! Failed connections use exponential backoff to avoid overwhelming peers.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::{Duration as ChronoDuration, Utc};
 use tokio::net::TcpStream;
 
 use crate::feed::engine::FeedEngine;
+use crate::gossip::backoff::ExponentialBackoff;
 use crate::gossip::connection::SecureConnection;
 use crate::gossip::health::HEALTH_EVICTION_HOURS;
+use crate::gossip::persistent::PersistentConnectionTask;
+use crate::gossip::registry::{ConnectionHandle, ConnectionRegistry};
 use crate::gossip::replication::{self, ReplicationConfig};
-use crate::identity::Identity;
+use crate::identity::{Identity, PublicId};
 
 /// Max time for a single peer sync (connect + handshake + replication).
 const PEER_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Configuration for the sync loop.
+#[derive(Clone)]
+pub struct SyncConfig {
+    /// Static peers from CLI.
+    pub static_peers: Vec<String>,
+    /// Network key for SHS.
+    pub network_key: [u8; 32],
+    /// Local identity.
+    pub identity: Identity,
+    /// Sync interval.
+    pub interval: Duration,
+    /// Enable persistent push connections.
+    pub push_enabled: bool,
+    /// Initial backoff delay for failed connections.
+    pub backoff_initial: Duration,
+    /// Maximum backoff delay for failed connections.
+    pub backoff_max: Duration,
+}
+
+impl SyncConfig {
+    /// Create a new config with default backoff settings.
+    pub fn new(
+        static_peers: Vec<String>,
+        network_key: [u8; 32],
+        identity: Identity,
+        interval: Duration,
+        push_enabled: bool,
+    ) -> Self {
+        Self {
+            static_peers,
+            network_key,
+            identity,
+            interval,
+            push_enabled,
+            backoff_initial: Duration::from_secs(5),
+            backoff_max: Duration::from_secs(300),
+        }
+    }
+}
+
+/// Tracks backoff state for a peer address.
+struct PeerBackoff {
+    backoff: ExponentialBackoff,
+    /// When the current backoff expires (peer can be retried).
+    retry_after: Option<Instant>,
+}
 
 /// Periodically sync with known peers.
 /// `static_peers` are CLI-provided addresses that never change.
@@ -35,11 +89,25 @@ pub async fn run_sync_loop(
     engine: Arc<FeedEngine>,
     interval: Duration,
 ) {
+    let config = SyncConfig::new(static_peers, network_key, identity, interval, false);
+    run_sync_loop_with_push(config, engine, None).await;
+}
+
+/// Periodically sync with known peers, with optional push support.
+pub async fn run_sync_loop_with_push(
+    config: SyncConfig,
+    engine: Arc<FeedEngine>,
+    registry: Option<Arc<ConnectionRegistry>>,
+) {
     tracing::info!(
-        static_peer_count = static_peers.len(),
-        interval_secs = interval.as_secs(),
+        static_peer_count = config.static_peers.len(),
+        interval_secs = config.interval.as_secs(),
+        push_enabled = config.push_enabled,
         "gossip sync loop started"
     );
+
+    // Track backoff state per peer address
+    let mut peer_backoffs: HashMap<String, PeerBackoff> = HashMap::new();
 
     loop {
         // Evict stale health records (Consul-style 72-hour TTL)
@@ -62,7 +130,7 @@ pub async fn run_sync_loop(
         }
 
         // Build peer list: static CLI peers + DB peers
-        let mut peer_set: HashSet<String> = static_peers.iter().cloned().collect();
+        let mut peer_set: HashSet<String> = config.static_peers.iter().cloned().collect();
 
         let db_engine = engine.clone();
         match tokio::task::spawn_blocking(move || {
@@ -83,18 +151,89 @@ pub async fn run_sync_loop(
 
         if peer_set.is_empty() {
             tracing::debug!("no peers available, waiting for next cycle");
-            tokio::time::sleep(interval).await;
+            tokio::time::sleep(config.interval).await;
             continue;
         }
 
+        // Clean up backoff entries for peers no longer in the peer set
+        peer_backoffs.retain(|addr, _| peer_set.contains(addr));
+
         // Build replication config from current follows
-        let config = build_replication_config(&engine).await;
+        let repl_config = build_replication_config(&engine).await;
 
         for peer_addr in &peer_set {
-            sync_one_peer(peer_addr, network_key, &identity, &engine, &config).await;
+            // Check if this peer is in backoff
+            let now = Instant::now();
+            if let Some(backoff) = peer_backoffs.get(peer_addr) {
+                if let Some(retry_after) = backoff.retry_after {
+                    if now < retry_after {
+                        tracing::trace!(
+                            peer = %peer_addr,
+                            retry_in_secs = (retry_after - now).as_secs(),
+                            "peer in backoff, skipping"
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            let result = sync_one_peer(
+                peer_addr,
+                &config,
+                &engine,
+                &repl_config,
+                registry.as_ref(),
+            )
+            .await;
+
+            // Update backoff based on result
+            match result {
+                SyncResult::Success => {
+                    // Reset backoff on success
+                    if let Some(backoff) = peer_backoffs.get_mut(peer_addr) {
+                        backoff.backoff.reset();
+                        backoff.retry_after = None;
+                    }
+                }
+                SyncResult::Failed => {
+                    // Apply backoff on failure
+                    let backoff = peer_backoffs
+                        .entry(peer_addr.clone())
+                        .or_insert_with(|| PeerBackoff {
+                            backoff: ExponentialBackoff::new(
+                                config.backoff_initial,
+                                config.backoff_max,
+                            ),
+                            retry_after: None,
+                        });
+                    let delay = backoff.backoff.next_delay();
+                    backoff.retry_after = Some(now + delay);
+
+                    if backoff.backoff.is_extended() {
+                        tracing::warn!(
+                            peer = %peer_addr,
+                            attempt = backoff.backoff.attempt(),
+                            next_retry_secs = delay.as_secs(),
+                            "peer consistently failing, extended backoff"
+                        );
+                    } else {
+                        tracing::debug!(
+                            peer = %peer_addr,
+                            next_retry_secs = delay.as_secs(),
+                            "backing off from peer"
+                        );
+                    }
+                }
+            }
         }
-        tokio::time::sleep(interval).await;
+        tokio::time::sleep(config.interval).await;
     }
+}
+
+/// Result of a sync attempt.
+enum SyncResult {
+    Success,
+    Failed,
 }
 
 pub(crate) async fn build_replication_config(engine: &Arc<FeedEngine>) -> ReplicationConfig {
@@ -117,70 +256,153 @@ pub(crate) async fn build_replication_config(engine: &Arc<FeedEngine>) -> Replic
 }
 
 /// Sync with a single peer, with timeout and result logging.
+/// Returns SyncResult for backoff tracking.
 async fn sync_one_peer(
     peer_addr: &str,
-    network_key: [u8; 32],
-    identity: &Identity,
+    config: &SyncConfig,
     engine: &Arc<FeedEngine>,
-    config: &ReplicationConfig,
-) {
+    repl_config: &ReplicationConfig,
+    registry: Option<&Arc<ConnectionRegistry>>,
+) -> SyncResult {
     tracing::debug!(peer = %peer_addr, "initiating gossip sync");
     let sync_result = tokio::time::timeout(
         PEER_SYNC_TIMEOUT,
-        sync_with_peer(peer_addr, network_key, identity.clone(), engine, config),
+        sync_with_peer(peer_addr, config, engine, repl_config, registry),
     )
     .await;
     match sync_result {
-        Ok(Ok(remote_id)) => {
-            tracing::info!(peer = %peer_addr, "gossip sync complete");
-            if let Some(pub_id_str) = remote_id {
-                let addr = peer_addr.to_string();
-                let eng = engine.clone();
-                let pub_id_for_health = pub_id_str.clone();
-                if let Err(e) = tokio::task::spawn_blocking(move || {
-                    let store = eng.store();
-                    // Update address peer sync timestamp
-                    if let Err(e) = store.update_address_peer_synced(&addr, &pub_id_str) {
-                        tracing::warn!(error = %e, "failed to update peer sync timestamp");
-                    }
-
-                    // Record direct observation for mesh health
-                    let pub_id = crate::identity::PublicId(pub_id_for_health);
-                    let their_seq = store.get_latest_sequence(&pub_id).unwrap_or(0);
-                    let our_gen = store.get_local_generation().unwrap_or(0);
-                    if let Err(e) = store.record_direct_observation(&pub_id, their_seq, our_gen) {
-                        tracing::warn!(error = %e, "failed to record direct observation");
-                    }
-                })
-                .await
-                {
-                    tracing::warn!(error = %e, "peer sync update task failed");
-                }
-            }
+        Ok(Ok(SyncOutcome::PullComplete(remote_id))) => {
+            tracing::info!(peer = %peer_addr, "gossip sync complete (pull mode)");
+            update_peer_health(engine, peer_addr, &remote_id).await;
+            SyncResult::Success
         }
-        Ok(Err(e)) => tracing::warn!(peer = %peer_addr, error = %e, "gossip sync failed"),
-        Err(_) => tracing::warn!(peer = %peer_addr, "gossip sync timed out"),
+        Ok(Ok(SyncOutcome::PersistentEstablished(remote_id))) => {
+            tracing::info!(peer = %peer_addr, "gossip sync complete (persistent mode)");
+            update_peer_health(engine, peer_addr, &remote_id).await;
+            SyncResult::Success
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(peer = %peer_addr, error = %e, "gossip sync failed");
+            SyncResult::Failed
+        }
+        Err(_) => {
+            tracing::warn!(peer = %peer_addr, "gossip sync timed out");
+            SyncResult::Failed
+        }
     }
 }
 
-/// Returns the remote peer's public ID string on success.
+/// Outcome of a peer sync operation.
+enum SyncOutcome {
+    /// Pull-only replication completed and connection closed.
+    PullComplete(PublicId),
+    /// Persistent connection established (task spawned).
+    PersistentEstablished(PublicId),
+}
+
+/// Sync with a peer and optionally establish persistent connection.
 async fn sync_with_peer(
     addr: &str,
-    network_key: [u8; 32],
-    identity: Identity,
+    config: &SyncConfig,
     engine: &Arc<FeedEngine>,
-    config: &ReplicationConfig,
-) -> crate::error::Result<Option<String>> {
+    repl_config: &ReplicationConfig,
+    registry: Option<&Arc<ConnectionRegistry>>,
+) -> crate::error::Result<SyncOutcome> {
     let stream = tokio::time::timeout(Duration::from_secs(10), TcpStream::connect(addr))
         .await
-        .map_err(|_| crate::error::EgreError::Io(std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            format!("TCP connect to {addr} timed out"),
-        )))?
-        ?;
-    let mut conn = SecureConnection::connect(stream, network_key, identity).await?;
-    let remote_pub_id = crate::identity::PublicId::from_verifying_key(&conn.remote_public_key);
-    replication::replicate_as_client(&mut conn, engine, config).await?;
+        .map_err(|_| {
+            crate::error::EgreError::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("TCP connect to {addr} timed out"),
+            ))
+        })??;
+
+    let peer_addr = stream.peer_addr()?;
+    let mut conn =
+        SecureConnection::connect(stream, config.network_key, config.identity.clone()).await?;
+    let remote_pub_id = PublicId::from_verifying_key(&conn.remote_public_key);
+
+    // Run standard replication
+    replication::replicate_as_client(&mut conn, engine, repl_config).await?;
+
+    // Attempt persistent mode if enabled
+    if config.push_enabled {
+        if let Some(reg) = registry {
+            // Check if we're already connected to this peer
+            if reg.is_connected(&remote_pub_id) {
+                tracing::debug!(
+                    peer = %remote_pub_id.0,
+                    "already have persistent connection, closing"
+                );
+                conn.close().await?;
+                return Ok(SyncOutcome::PullComplete(remote_pub_id));
+            }
+
+            // Negotiate persistent mode
+            if replication::negotiate_persistent_mode_client(&mut conn).await? {
+                // Split connection for concurrent I/O
+                let (reader, writer) = conn.into_split();
+
+                // Register the writer half
+                let handle =
+                    ConnectionHandle::new(writer, remote_pub_id.clone(), peer_addr, true);
+
+                if reg.register(handle) {
+                    // Spawn task to handle incoming Push messages
+                    let task = PersistentConnectionTask::new(
+                        reader,
+                        remote_pub_id.clone(),
+                        engine.clone(),
+                        reg.clone(),
+                    );
+                    tokio::spawn(async move {
+                        if let Err(e) = task.run().await {
+                            tracing::debug!(error = %e, "persistent connection task ended");
+                        }
+                    });
+
+                    return Ok(SyncOutcome::PersistentEstablished(remote_pub_id));
+                } else {
+                    // Registration failed (at capacity or duplicate)
+                    // Reader/writer will be dropped, connection closes automatically
+                    tracing::debug!(
+                        peer = %remote_pub_id.0,
+                        "failed to register persistent connection"
+                    );
+                    return Ok(SyncOutcome::PullComplete(remote_pub_id));
+                }
+            }
+        }
+    }
+
+    // Fall back to pull-only mode
     conn.close().await?;
-    Ok(Some(remote_pub_id.0))
+    Ok(SyncOutcome::PullComplete(remote_pub_id))
+}
+
+/// Update peer health records after successful sync.
+async fn update_peer_health(engine: &Arc<FeedEngine>, peer_addr: &str, remote_id: &PublicId) {
+    let addr = peer_addr.to_string();
+    let eng = engine.clone();
+    let pub_id_str = remote_id.0.clone();
+    let pub_id_for_health = remote_id.clone();
+
+    if let Err(e) = tokio::task::spawn_blocking(move || {
+        let store = eng.store();
+        // Update address peer sync timestamp
+        if let Err(e) = store.update_address_peer_synced(&addr, &pub_id_str) {
+            tracing::warn!(error = %e, "failed to update peer sync timestamp");
+        }
+
+        // Record direct observation for mesh health
+        let their_seq = store.get_latest_sequence(&pub_id_for_health).unwrap_or(0);
+        let our_gen = store.get_local_generation().unwrap_or(0);
+        if let Err(e) = store.record_direct_observation(&pub_id_for_health, their_seq, our_gen) {
+            tracing::warn!(error = %e, "failed to record direct observation");
+        }
+    })
+    .await
+    {
+        tracing::warn!(error = %e, "peer sync update task failed");
+    }
 }

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -1,7 +1,11 @@
+pub mod backoff;
 pub mod client;
 pub mod connection;
 pub mod discovery;
 pub mod health;
 pub mod peers;
+pub mod persistent;
+pub mod push;
+pub mod registry;
 pub mod replication;
 pub mod server;

--- a/src/gossip/persistent.rs
+++ b/src/gossip/persistent.rs
@@ -1,0 +1,156 @@
+//! Persistent connection task for push-based replication.
+//!
+//! Handles the lifecycle of a persistent connection after initial replication
+//! completes. Runs as an async task, processing incoming Push messages and
+//! detecting connection failures.
+
+use std::sync::Arc;
+
+use crate::error::{EgreError, Result};
+use crate::feed::engine::FeedEngine;
+use crate::gossip::connection::SecureReader;
+use crate::gossip::registry::ConnectionRegistry;
+use crate::gossip::replication::GossipMessage;
+use crate::identity::PublicId;
+
+/// Task that handles incoming messages on a persistent connection.
+///
+/// Runs until the connection is closed or an error occurs. On completion,
+/// automatically unregisters from the connection registry.
+pub struct PersistentConnectionTask {
+    reader: SecureReader,
+    peer_id: PublicId,
+    engine: Arc<FeedEngine>,
+    registry: Arc<ConnectionRegistry>,
+}
+
+impl PersistentConnectionTask {
+    /// Create a new persistent connection task.
+    pub fn new(
+        reader: SecureReader,
+        peer_id: PublicId,
+        engine: Arc<FeedEngine>,
+        registry: Arc<ConnectionRegistry>,
+    ) -> Self {
+        Self {
+            reader,
+            peer_id,
+            engine,
+            registry,
+        }
+    }
+
+    /// Run the task, processing incoming messages until connection closes.
+    ///
+    /// Returns `Ok(())` on graceful shutdown, `Err` on protocol or I/O errors.
+    pub async fn run(mut self) -> Result<()> {
+        tracing::debug!(peer = %self.peer_id.0, "persistent connection task started");
+
+        let result = self.process_loop().await;
+
+        // Always unregister on exit
+        self.registry.unregister(&self.peer_id);
+
+        match &result {
+            Ok(()) => {
+                tracing::info!(peer = %self.peer_id.0, "persistent connection closed gracefully");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    peer = %self.peer_id.0,
+                    error = %e,
+                    "persistent connection ended with error"
+                );
+            }
+        }
+
+        result
+    }
+
+    /// Main processing loop for incoming messages.
+    async fn process_loop(&mut self) -> Result<()> {
+        loop {
+            match self.reader.recv().await {
+                Ok(Some(data)) => {
+                    self.handle_message(&data).await?;
+                }
+                Ok(None) => {
+                    // Graceful close (goodbye or EOF)
+                    return Ok(());
+                }
+                Err(e) => {
+                    // I/O or protocol error
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Handle a single incoming message.
+    async fn handle_message(&self, data: &[u8]) -> Result<()> {
+        let msg: GossipMessage = serde_json::from_slice(data)?;
+
+        match msg {
+            GossipMessage::Push { message } => {
+                tracing::debug!(
+                    peer = %self.peer_id.0,
+                    author = %message.author.0,
+                    seq = message.sequence,
+                    hash = %message.hash,
+                    "received pushed message"
+                );
+
+                // Ingest on blocking task (SQLite)
+                let eng = self.engine.clone();
+                let msg_clone = message.clone();
+                let result = tokio::task::spawn_blocking(move || eng.ingest(&msg_clone)).await;
+
+                match result {
+                    Ok(Ok(())) => {
+                        tracing::debug!(hash = %message.hash, "ingested pushed message");
+                    }
+                    Ok(Err(EgreError::DuplicateMessage { .. })) => {
+                        // Already have this message, not an error
+                        tracing::trace!(hash = %message.hash, "pushed message is duplicate");
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            hash = %message.hash,
+                            error = %e,
+                            "failed to ingest pushed message"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "spawn_blocking failed for ingest");
+                    }
+                }
+            }
+            GossipMessage::Have { .. }
+            | GossipMessage::Want { .. }
+            | GossipMessage::Messages { .. }
+            | GossipMessage::Done => {
+                // Replication messages shouldn't appear in persistent mode
+                tracing::warn!(
+                    peer = %self.peer_id.0,
+                    msg_type = ?msg,
+                    "unexpected replication message on persistent connection"
+                );
+            }
+            GossipMessage::Subscribe { .. } | GossipMessage::SubscribeAck { .. } => {
+                // Already negotiated, shouldn't receive these again
+                tracing::warn!(
+                    peer = %self.peer_id.0,
+                    "received Subscribe/SubscribeAck on active persistent connection"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests would go here, but they require full setup
+    // of SecureConnection pairs which is complex to mock
+}

--- a/src/gossip/push.rs
+++ b/src/gossip/push.rs
@@ -1,0 +1,98 @@
+//! Push manager for broadcasting messages to connected peers.
+//!
+//! Subscribes to FeedEngine events and broadcasts Push messages to all
+//! registered persistent connections via the ConnectionRegistry.
+
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use crate::feed::engine::FeedEngine;
+use crate::feed::models::Message;
+use crate::gossip::registry::ConnectionRegistry;
+
+/// Manages push-based message broadcasting to connected peers.
+///
+/// Listens for new messages from the FeedEngine and broadcasts them
+/// to all active persistent connections.
+pub struct PushManager {
+    registry: Arc<ConnectionRegistry>,
+    engine: Arc<FeedEngine>,
+}
+
+impl PushManager {
+    /// Create a new push manager.
+    pub fn new(registry: Arc<ConnectionRegistry>, engine: Arc<FeedEngine>) -> Self {
+        Self { registry, engine }
+    }
+
+    /// Start the push manager loop.
+    ///
+    /// Subscribes to the FeedEngine's broadcast channel and pushes each
+    /// new message to all connected peers. Runs until the channel closes.
+    pub async fn run(self) {
+        let mut rx = self.engine.subscribe();
+
+        tracing::info!("push manager started");
+
+        loop {
+            match rx.recv().await {
+                Ok(msg) => {
+                    self.handle_message(&msg).await;
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        skipped = n,
+                        "push manager lagged, some messages not broadcast"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("push manager stopping (channel closed)");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Handle a new message by broadcasting to all connected peers.
+    async fn handle_message(&self, msg: &Message) {
+        let conn_count = self.registry.connection_count();
+        if conn_count == 0 {
+            // No persistent connections, nothing to broadcast
+            return;
+        }
+
+        tracing::debug!(
+            hash = %msg.hash,
+            author = %msg.author.0,
+            seq = msg.sequence,
+            connections = conn_count,
+            "broadcasting message to persistent connections"
+        );
+
+        self.registry.broadcast(msg).await;
+    }
+
+    /// Get a reference to the connection registry.
+    pub fn registry(&self) -> &Arc<ConnectionRegistry> {
+        &self.registry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feed::store::FeedStore;
+
+    #[tokio::test]
+    async fn push_manager_handles_no_connections() {
+        let store = FeedStore::open_memory().unwrap();
+        let engine = Arc::new(FeedEngine::new(store));
+        let registry = Arc::new(ConnectionRegistry::new(32));
+
+        let manager = PushManager::new(registry.clone(), engine.clone());
+
+        // With no connections, broadcast should be a no-op
+        assert_eq!(manager.registry().connection_count(), 0);
+    }
+}

--- a/src/gossip/registry.rs
+++ b/src/gossip/registry.rs
@@ -1,0 +1,353 @@
+//! Connection registry for persistent push-based connections.
+//!
+//! Tracks active persistent connections and provides broadcast capability.
+//! Uses DashMap for lock-free concurrent access from multiple tasks.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use tokio::sync::Mutex;
+
+use crate::error::Result;
+use crate::feed::models::Message;
+use crate::gossip::connection::SecureWriter;
+use crate::gossip::replication::GossipMessage;
+use crate::identity::PublicId;
+
+/// Handle to a persistent connection's write half.
+///
+/// Stored in the registry for broadcasting messages to connected peers.
+pub struct ConnectionHandle {
+    /// The write half, guarded by a mutex for exclusive send access.
+    writer: Arc<Mutex<SecureWriter>>,
+    /// The remote peer's public identity.
+    pub peer_id: PublicId,
+    /// The remote peer's socket address.
+    pub peer_addr: SocketAddr,
+    /// When this connection was established.
+    pub established_at: Instant,
+    /// True if we initiated this connection (client), false if incoming (server).
+    pub is_outgoing: bool,
+}
+
+impl ConnectionHandle {
+    /// Create a new connection handle.
+    pub fn new(
+        writer: SecureWriter,
+        peer_id: PublicId,
+        peer_addr: SocketAddr,
+        is_outgoing: bool,
+    ) -> Self {
+        Self {
+            writer: Arc::new(Mutex::new(writer)),
+            peer_id,
+            peer_addr,
+            established_at: Instant::now(),
+            is_outgoing,
+        }
+    }
+
+    /// Send a message over this connection.
+    pub async fn send(&self, msg: &GossipMessage) -> Result<()> {
+        let data = serde_json::to_vec(msg)?;
+        let mut writer = self.writer.lock().await;
+        writer.send(&data).await
+    }
+
+    /// Get the writer for direct access (e.g., for goodbye).
+    pub fn writer(&self) -> Arc<Mutex<SecureWriter>> {
+        self.writer.clone()
+    }
+}
+
+/// Metrics for connection tracking.
+#[derive(Default)]
+pub struct ConnectionMetrics {
+    /// Total messages broadcast since startup.
+    pub messages_broadcast: AtomicU64,
+    /// Total push messages sent (across all connections).
+    pub pushes_sent: AtomicU64,
+    /// Total push send failures.
+    pub push_failures: AtomicU64,
+}
+
+/// Registry of active persistent connections.
+///
+/// Thread-safe, lock-free access for concurrent connection management
+/// and message broadcasting.
+pub struct ConnectionRegistry {
+    /// Active connections indexed by peer public ID.
+    connections: DashMap<PublicId, ConnectionHandle>,
+    /// Maximum allowed persistent connections.
+    max_connections: usize,
+    /// Metrics for monitoring.
+    pub metrics: ConnectionMetrics,
+}
+
+impl ConnectionRegistry {
+    /// Create a new registry with the given connection limit.
+    pub fn new(max_connections: usize) -> Self {
+        Self {
+            connections: DashMap::new(),
+            max_connections,
+            metrics: ConnectionMetrics::default(),
+        }
+    }
+
+    /// Register a new persistent connection.
+    ///
+    /// Returns `false` if the connection limit is reached or the peer is
+    /// already registered (duplicate connection).
+    ///
+    /// Uses atomic entry API to avoid TOCTOU race conditions.
+    pub fn register(&self, handle: ConnectionHandle) -> bool {
+        let peer_id = handle.peer_id.clone();
+
+        // Check connection limit first (may slightly over-accept under high concurrency,
+        // but that's acceptable for a soft limit)
+        if self.connections.len() >= self.max_connections {
+            tracing::warn!(
+                peer = %peer_id.0,
+                limit = self.max_connections,
+                "connection limit reached, rejecting"
+            );
+            return false;
+        }
+
+        // Use entry API for atomic check-and-insert
+        use dashmap::mapref::entry::Entry;
+        match self.connections.entry(peer_id.clone()) {
+            Entry::Occupied(_) => {
+                tracing::debug!(peer = %peer_id.0, "duplicate connection, rejecting");
+                false
+            }
+            Entry::Vacant(entry) => {
+                tracing::info!(
+                    peer = %peer_id.0,
+                    addr = %handle.peer_addr,
+                    direction = if handle.is_outgoing { "outgoing" } else { "incoming" },
+                    "registered persistent connection"
+                );
+                entry.insert(handle);
+                true
+            }
+        }
+    }
+
+    /// Unregister a connection by peer ID.
+    ///
+    /// Returns the removed handle if it existed.
+    pub fn unregister(&self, peer_id: &PublicId) -> Option<ConnectionHandle> {
+        if let Some((_, handle)) = self.connections.remove(peer_id) {
+            tracing::info!(
+                peer = %peer_id.0,
+                duration_secs = handle.established_at.elapsed().as_secs(),
+                "unregistered persistent connection"
+            );
+            Some(handle)
+        } else {
+            None
+        }
+    }
+
+    /// Check if a peer is currently connected.
+    pub fn is_connected(&self, peer_id: &PublicId) -> bool {
+        self.connections.contains_key(peer_id)
+    }
+
+    /// Get the number of active connections.
+    pub fn connection_count(&self) -> usize {
+        self.connections.len()
+    }
+
+    /// Get a list of all connected peer IDs.
+    pub fn connected_peers(&self) -> Vec<PublicId> {
+        self.connections.iter().map(|r| r.key().clone()).collect()
+    }
+
+    /// Broadcast a message to all connected peers.
+    ///
+    /// Sends concurrently to all connections using parallel futures.
+    /// Failed sends are logged and connections are removed.
+    pub async fn broadcast(&self, msg: &Message) {
+        let gossip_msg = GossipMessage::Push {
+            message: msg.clone(),
+        };
+
+        self.metrics.messages_broadcast.fetch_add(1, Ordering::Relaxed);
+
+        // Collect handles first to avoid holding DashMap references across await
+        let peers: Vec<(PublicId, Arc<Mutex<SecureWriter>>)> = self
+            .connections
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().writer()))
+            .collect();
+
+        if peers.is_empty() {
+            return;
+        }
+
+        // Send to all connections concurrently
+        let msg_data = match serde_json::to_vec(&gossip_msg) {
+            Ok(data) => data,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to serialize push message");
+                return;
+            }
+        };
+
+        let send_futures = peers.iter().map(|(peer_id, writer)| {
+            let peer_id = peer_id.clone();
+            let writer = writer.clone();
+            let data = msg_data.clone();
+            let hash = msg.hash.clone();
+            async move {
+                let result = {
+                    let mut w = writer.lock().await;
+                    w.send(&data).await
+                };
+                (peer_id, hash, result)
+            }
+        });
+
+        let results = futures::future::join_all(send_futures).await;
+
+        let mut failed_peers = Vec::new();
+        for (peer_id, hash, result) in results {
+            match result {
+                Ok(()) => {
+                    self.metrics.pushes_sent.fetch_add(1, Ordering::Relaxed);
+                    tracing::debug!(
+                        peer = %peer_id.0,
+                        hash = %hash,
+                        "pushed message"
+                    );
+                }
+                Err(e) => {
+                    self.metrics.push_failures.fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!(
+                        peer = %peer_id.0,
+                        error = %e,
+                        "failed to push message, marking for removal"
+                    );
+                    failed_peers.push(peer_id);
+                }
+            }
+        }
+
+        // Remove failed connections
+        for peer_id in failed_peers {
+            self.unregister(&peer_id);
+        }
+    }
+
+    /// Get connection info for status reporting.
+    pub fn connection_info(&self) -> Vec<ConnectionInfo> {
+        self.connections
+            .iter()
+            .map(|entry| {
+                let handle = entry.value();
+                ConnectionInfo {
+                    peer_id: handle.peer_id.clone(),
+                    peer_addr: handle.peer_addr,
+                    established_at: handle.established_at,
+                    is_outgoing: handle.is_outgoing,
+                }
+            })
+            .collect()
+    }
+
+    /// Gracefully close all persistent connections.
+    ///
+    /// Sends goodbye frames to all connected peers and removes them from the registry.
+    /// Used during graceful shutdown.
+    pub async fn close_all(&self) {
+        let count = self.connections.len();
+        if count == 0 {
+            return;
+        }
+
+        tracing::info!(
+            connection_count = count,
+            "closing all persistent connections"
+        );
+
+        // Collect all connections to close
+        let peers: Vec<(PublicId, Arc<Mutex<SecureWriter>>)> = self
+            .connections
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().writer()))
+            .collect();
+
+        // Send goodbye to all concurrently
+        let goodbye_futures = peers.iter().map(|(peer_id, writer)| {
+            let peer_id = peer_id.clone();
+            let writer = writer.clone();
+            async move {
+                let result = {
+                    let mut w = writer.lock().await;
+                    w.goodbye().await
+                };
+                if let Err(e) = result {
+                    tracing::debug!(
+                        peer = %peer_id.0,
+                        error = %e,
+                        "failed to send goodbye"
+                    );
+                }
+                peer_id
+            }
+        });
+
+        let closed_peers = futures::future::join_all(goodbye_futures).await;
+
+        // Remove all from registry
+        for peer_id in closed_peers {
+            self.connections.remove(&peer_id);
+        }
+
+        tracing::info!("all persistent connections closed");
+    }
+}
+
+/// Summary info about a connection for status reporting.
+#[derive(Debug, Clone)]
+pub struct ConnectionInfo {
+    pub peer_id: PublicId,
+    pub peer_addr: SocketAddr,
+    pub established_at: Instant,
+    pub is_outgoing: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn mock_peer_id(n: u8) -> PublicId {
+        PublicId(format!("@test-peer-{}.ed25519", n))
+    }
+
+    fn mock_addr(port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
+    }
+
+    #[test]
+    fn registry_respects_max_connections() {
+        let registry = ConnectionRegistry::new(2);
+
+        // We can't easily mock SecureWriter, so we'll just test the logic
+        // through the public API where possible
+        assert_eq!(registry.connection_count(), 0);
+        assert!(!registry.is_connected(&mock_peer_id(1)));
+    }
+
+    #[test]
+    fn connected_peers_returns_all() {
+        let registry = ConnectionRegistry::new(10);
+        assert!(registry.connected_peers().is_empty());
+    }
+}

--- a/src/gossip/server.rs
+++ b/src/gossip/server.rs
@@ -7,6 +7,9 @@
 //! Default: no authorization — accepts any peer on the same network key.
 //! With AuthorizeFn: checks known_peers.authorized, rejecting unauthorized peers.
 //!
+//! With push_enabled: After replication, responds to Subscribe requests and
+//! establishes persistent connections for push-based message broadcasting.
+//!
 //! Bounded by semaphore (64 concurrent) and per-connection timeout (120s)
 //! to prevent resource exhaustion.
 
@@ -20,14 +23,31 @@ use crate::error::Result;
 use crate::feed::engine::FeedEngine;
 use crate::gossip::client::build_replication_config;
 use crate::gossip::connection::SecureConnection;
+use crate::gossip::persistent::PersistentConnectionTask;
+use crate::gossip::registry::{ConnectionHandle, ConnectionRegistry};
 use crate::gossip::replication;
-use crate::identity::Identity;
+use crate::identity::{Identity, PublicId};
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_CONCURRENT_CONNECTIONS: usize = 64;
 
 /// Authorization callback: given a remote peer's VerifyingKey, return whether to allow.
 pub type AuthorizeFn = Arc<dyn Fn(&ed25519_dalek::VerifyingKey) -> bool + Send + Sync>;
+
+/// Configuration for the gossip server.
+#[derive(Clone)]
+pub struct ServerConfig {
+    /// Address to bind to.
+    pub bind_addr: String,
+    /// Network key for SHS.
+    pub network_key: [u8; 32],
+    /// Local identity.
+    pub identity: Identity,
+    /// Enable persistent push connections.
+    pub push_enabled: bool,
+    /// Maximum persistent connections (separate from replication semaphore).
+    pub max_persistent_connections: usize,
+}
 
 /// Start the gossip server listener (no authorization — accepts all peers).
 pub async fn run_server(
@@ -47,9 +67,31 @@ pub async fn run_server_with_auth(
     engine: Arc<FeedEngine>,
     authorize: Option<AuthorizeFn>,
 ) -> Result<()> {
-    let listener = TcpListener::bind(&bind_addr).await?;
+    let config = ServerConfig {
+        bind_addr,
+        network_key,
+        identity,
+        push_enabled: false,
+        max_persistent_connections: 32,
+    };
+    run_server_with_push(config, engine, None, authorize).await
+}
+
+/// Start the gossip server with push support.
+pub async fn run_server_with_push(
+    config: ServerConfig,
+    engine: Arc<FeedEngine>,
+    registry: Option<Arc<ConnectionRegistry>>,
+    authorize: Option<AuthorizeFn>,
+) -> Result<()> {
+    let listener = TcpListener::bind(&config.bind_addr).await?;
     let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_CONNECTIONS));
-    tracing::info!(addr = %bind_addr, max_conns = MAX_CONCURRENT_CONNECTIONS, "gossip server listening");
+    tracing::info!(
+        addr = %config.bind_addr,
+        max_conns = MAX_CONCURRENT_CONNECTIONS,
+        push_enabled = config.push_enabled,
+        "gossip server listening"
+    );
 
     loop {
         let (stream, peer_addr) = match listener.accept().await {
@@ -69,16 +111,19 @@ pub async fn run_server_with_auth(
             }
         };
 
-        let net_key = network_key;
-        let id = identity.clone();
+        let net_key = config.network_key;
+        let id = config.identity.clone();
         let eng = engine.clone();
         let auth = authorize.clone();
+        let push_enabled = config.push_enabled;
+        let reg = registry.clone();
 
         tokio::spawn(async move {
             let _permit = permit; // held until task completes
             tracing::info!(peer = %peer_addr, "incoming gossip connection");
             let result = tokio::time::timeout(CONNECTION_TIMEOUT, async {
                 let mut conn = SecureConnection::accept(stream, net_key, id).await?;
+                let remote_pub_id = PublicId::from_verifying_key(&conn.remote_public_key);
 
                 // Check authorization if callback provided
                 if let Some(ref auth_fn) = auth {
@@ -89,12 +134,67 @@ pub async fn run_server_with_auth(
                     }
                 }
 
-                let config = build_replication_config(&eng).await;
+                let repl_config = build_replication_config(&eng).await;
                 if let Err(e) =
-                    replication::replicate_as_server(&mut conn, &eng, &config).await
+                    replication::replicate_as_server(&mut conn, &eng, &repl_config).await
                 {
                     tracing::warn!(peer = %peer_addr, error = %e, "replication error");
+                    let _ = conn.close().await;
+                    return Ok(());
                 }
+
+                // Check for persistent mode negotiation
+                if push_enabled {
+                    if let Some(ref registry) = reg {
+                        // Check if already connected
+                        let already_connected = registry.is_connected(&remote_pub_id);
+
+                        if let Ok(accepted) = replication::negotiate_persistent_mode_server(
+                            &mut conn,
+                            push_enabled,
+                            already_connected,
+                        )
+                        .await
+                        {
+                            if accepted {
+                                // Split connection for concurrent I/O
+                                let socket_addr = conn.peer_addr().unwrap_or(peer_addr);
+                                let (reader, writer) = conn.into_split();
+
+                                // Register the writer half
+                                let handle = ConnectionHandle::new(
+                                    writer,
+                                    remote_pub_id.clone(),
+                                    socket_addr,
+                                    false, // incoming connection
+                                );
+
+                                if registry.register(handle) {
+                                    // Spawn task to handle incoming Push messages
+                                    let task = PersistentConnectionTask::new(
+                                        reader,
+                                        remote_pub_id.clone(),
+                                        eng.clone(),
+                                        registry.clone(),
+                                    );
+                                    tokio::spawn(async move {
+                                        if let Err(e) = task.run().await {
+                                            tracing::debug!(
+                                                error = %e,
+                                                "persistent connection task ended"
+                                            );
+                                        }
+                                    });
+                                    return Ok(());
+                                }
+                                // Registration failed, reader/writer dropped, conn closed
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+
+                // Fall back to closing connection
                 let _ = conn.close().await;
                 Ok::<(), crate::error::EgreError>(())
             })


### PR DESCRIPTION
## Summary

Add persistent connections with push-based message propagation. After initial Have/Want/Messages/Done exchange, nodes can negotiate persistent mode for real-time Push notifications. Pull-based gossip remains as fallback/recovery.

### New modules
- `gossip/registry.rs`: ConnectionRegistry with DashMap for lock-free access
- `gossip/push.rs`: PushManager broadcasts to all connected peers
- `gossip/persistent.rs`: PersistentConnectionTask handles incoming Push messages
- `gossip/backoff.rs`: ExponentialBackoff with jitter for reconnection

### Protocol additions
- `Push { message }`: Real-time message notification
- `Subscribe { mode }`: Request persistent connection
- `SubscribeAck { accepted, mode }`: Negotiation response

### Key features
- SecureReader/SecureWriter for concurrent bidirectional I/O
- Parallel broadcast using `futures::future::join_all`
- Atomic registration using DashMap entry API (TOCTOU prevention)
- Graceful shutdown sends goodbye to all persistent connections
- Per-peer exponential backoff with jitter for reconnection

### Configuration
| Setting | Default | Description |
|---------|---------|-------------|
| `push_enabled` | `false` | Enable persistent connections |
| `max_persistent_connections` | `32` | Limit concurrent connections |
| `reconnect_initial_secs` | `5` | Initial backoff delay |
| `reconnect_max_secs` | `300` | Max backoff delay |

### Backward compatibility
- Old nodes close after replication, new nodes detect this and fall back to pull mode gracefully
- No breaking changes to existing API or wire protocol for pull-only nodes

## Test plan
- [x] `cargo test` - all 130 tests pass
- [x] `cargo clippy` - no warnings
- [x] `cargo build --release` - successful
- [ ] Manual testing with two nodes (push-enabled)
- [ ] Manual testing mixed mode (one push, one pull-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)