### PR TITLE
feat: enable push-based replication by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The node runs on the agent's machine. Generates an Ed25519 identity on first run
 | `--peer` | none | Static gossip peer (host:port, repeatable) |
 | `--lan-discovery` | off | Enable UDP LAN peer discovery |
 | `--discovery-port` | `7656` | UDP discovery port |
-| `--push-enabled` | off | Enable persistent push connections |
+| `--no-push` | off | Disable persistent push connections (push is on by default) |
 | `--max-persistent-connections` | `32` | Max persistent connections |
 
 ### Interfaces

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,7 +83,7 @@ impl Default for Config {
             lan_discovery: false,
             discovery_port: 7656,
             hooks: Vec::new(),
-            push_enabled: false,
+            push_enabled: true,
             max_persistent_connections: default_max_persistent_connections(),
             reconnect_initial_secs: default_reconnect_initial_secs(),
             reconnect_max_secs: default_reconnect_max_secs(),

--- a/src/config_template.yaml
+++ b/src/config_template.yaml
@@ -65,8 +65,8 @@ hooks: []
 # real-time message propagation (in addition to periodic pull sync).
 
 # Enable persistent push connections.
-# Default: false
-push_enabled: false
+# Default: true
+push_enabled: true
 
 # Maximum number of persistent connections to maintain.
 # Applies to both incoming and outgoing persistent connections.

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,9 +81,9 @@ struct Cli {
     #[arg(long)]
     init_config: bool,
 
-    /// Enable persistent push-based connections for real-time message propagation
+    /// Disable persistent push-based connections (push is enabled by default)
     #[arg(long)]
-    push_enabled: bool,
+    no_push: bool,
 
     /// Maximum number of persistent connections to maintain
     #[arg(long)]
@@ -156,9 +156,9 @@ fn build_config(cli: &Cli, matches: &clap::ArgMatches) -> anyhow::Result<Config>
         config.hooks.push(cli_hook);
     }
 
-    // Push configuration
-    if matches.value_source("push_enabled") == Some(ValueSource::CommandLine) {
-        config.push_enabled = cli.push_enabled;
+    // Push configuration (push is enabled by default, --no-push disables)
+    if cli.no_push {
+        config.push_enabled = false;
     }
     if let Some(max_conns) = cli.max_persistent_connections {
         config.max_persistent_connections = max_conns;


### PR DESCRIPTION
## Summary
- Push-based replication is now enabled by default
- All nodes benefit from real-time message propagation out of the box
- Pull-based sync remains as fallback (partition recovery, missed messages)
- Backward compatible: old nodes gracefully reject `Subscribe` and continue with pull

## Changes
- `Config::default()` now sets `push_enabled: true`
- CLI: replaced `--push-enabled` with `--no-push` (to disable)
- Updated config template and README

## Rationale
No strong reason to keep push opt-in:
- Lower latency is almost always desirable
- More efficient than periodic polling
- Fallback to pull is solid
- Feature has been tested in v0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)