### PR TITLE
fix: remove hardcoded paths from example hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ mcp/
 node_modules/
 dist/
 
+# Claude Code
+.claude/
+
 # Asha
 .asha/
 Memory/

--- a/examples/claude-hook/claude-agent-hook.py
+++ b/examples/claude-hook/claude-agent-hook.py
@@ -1,4 +1,4 @@
-#!/home/pknull/Code/egregore/.venv/bin/python3
+#!/usr/bin/env python3
 """
 Egregore hook using Claude Agent SDK.
 
@@ -181,7 +181,10 @@ Be concise and helpful. Do not claim to perform actions you cannot actually do."
     )
 
     # Configure client - use system Claude Code for proper auth
-    system_claude = "/home/pknull/.asdf/installs/nodejs/24.4.0/bin/claude"
+    system_claude = os.environ.get(
+        "CLAUDE_CODE_PATH",
+        "claude"
+    )
     options = ClaudeAgentOptions(
         cli_path=system_claude,
         mcp_servers={"egregore": server},

--- a/examples/claude-hook/claude-disciplined-hook.py
+++ b/examples/claude-hook/claude-disciplined-hook.py
@@ -1,4 +1,4 @@
-#!/home/pknull/Code/egregore/.venv/bin/python3
+#!/usr/bin/env python3
 """
 Egregore hook with execution discipline.
 
@@ -249,7 +249,7 @@ set in_reply_to to '{msg_hash}' to thread the conversation."""
     # Configure client - use system Claude Code for proper auth
     system_claude = os.environ.get(
         "CLAUDE_CODE_PATH",
-        "/home/pknull/.asdf/installs/nodejs/24.4.0/bin/claude"
+        "claude"
     )
     options = ClaudeAgentOptions(
         cli_path=system_claude,

--- a/examples/ollama-hook/ollama-hook.py
+++ b/examples/ollama-hook/ollama-hook.py
@@ -1,4 +1,4 @@
-#!/home/pknull/Code/egregore/.venv/bin/python3
+#!/usr/bin/env python3
 """
 Egregore hook using local Ollama.
 

--- a/examples/openai-hook/codex-hook.py
+++ b/examples/openai-hook/codex-hook.py
@@ -1,4 +1,4 @@
-#!/home/pknull/Code/egregore/.venv/bin/python3
+#!/usr/bin/env python3
 """
 Egregore hook using Codex CLI.
 

--- a/examples/openai-hook/openai-hook.py
+++ b/examples/openai-hook/openai-hook.py
@@ -1,4 +1,4 @@
-#!/home/pknull/Code/egregore/.venv/bin/python3
+#!/usr/bin/env python3
 """
 Egregore hook using OpenAI Python SDK.
 


### PR DESCRIPTION
## Summary
- Replace all system-specific shebangs (`#!/home/pknull/...`) with portable `#!/usr/bin/env python3` across 5 example hook scripts
- Replace hardcoded Claude Code binary paths with `CLAUDE_CODE_PATH` env var lookup (falling back to `claude` on `$PATH`)
- Add `.claude/` to `.gitignore` to prevent local Claude Code config from being committed

## Files changed
- `examples/claude-hook/claude-agent-hook.py` — shebang + claude path
- `examples/claude-hook/claude-disciplined-hook.py` — shebang + claude path default
- `examples/openai-hook/openai-hook.py` — shebang
- `examples/openai-hook/codex-hook.py` — shebang
- `examples/ollama-hook/ollama-hook.py` — shebang
- `.gitignore` — add `.claude/`

## Test plan
- [ ] Verify `#!/usr/bin/env python3` resolves correctly on target systems
- [ ] Verify `CLAUDE_CODE_PATH` override works when set
- [ ] Verify `.claude/` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)