### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name = "egregore"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "SSB-inspired decentralized knowledge sharing for LLMs"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bump for v1.1.0 release.

### What's new in 1.1.0

- **Self-update**: `egregore update` command to download and install latest releases from GitHub

## Test plan

- [x] Version updated in Cargo.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)