### PR TITLE
ci: add Linux ARM64 release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact: egregore
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: egregore
           - target: x86_64-apple-darwin
             os: macos-latest
             artifact: egregore
@@ -37,7 +40,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Linux ARM64 cross toolchain
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Build
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package (Unix)


### PR DESCRIPTION
## Summary\n- add  to release build matrix\n- install  when building that target\n- set Cargo linker env for ARM64 GNU target\n\nThis makes GitHub Releases publish a Linux ARM64 binary suitable for Raspberry Pi-class devices.\n