### PR TITLE
ci: fix Linux ARM64 release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
             os: ubuntu-latest
             artifact: egregore
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             artifact: egregore
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -40,15 +40,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install Linux ARM64 cross toolchain
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-
       - name: Build
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package (Unix)


### PR DESCRIPTION
## Summary\n- switch  job to \n- remove cross-compile linker/toolchain override\n\nThe previous cross build failed in release workflow. This builds ARM64 natively on GitHub's ARM runner.\n