### PR TITLE
feat: switch Docker to prebuilt binary from GitHub releases

### DIFF
--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,16 +1,26 @@
-FROM rust:1-bookworm AS builder
-
-WORKDIR /build
-COPY . .
-RUN cargo build --release -p egregore
-
 FROM debian:bookworm-slim
 
+ARG EGREGORE_VERSION=latest
+ARG TARGETARCH
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
+    ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/target/release/egregore /usr/local/bin/egregore
+RUN set -eux; \
+    case "$TARGETARCH" in \
+      amd64) ARCH="x86_64-unknown-linux-gnu" ;; \
+      arm64) ARCH="aarch64-unknown-linux-gnu" ;; \
+      *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    if [ "$EGREGORE_VERSION" = "latest" ]; then \
+      URL="https://github.com/pknull/egregore/releases/latest/download/egregore-${ARCH}.tar.gz"; \
+    else \
+      URL="https://github.com/pknull/egregore/releases/download/${EGREGORE_VERSION}/egregore-${ARCH}.tar.gz"; \
+    fi; \
+    curl -fsSL "$URL" | tar xz -C /usr/local/bin egregore; \
+    chmod +x /usr/local/bin/egregore; \
+    egregore --version
 
 VOLUME /data
 

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   egregore:
-    build:
-      context: ../..
-      dockerfile: example/docker/Dockerfile
+    build: .
     container_name: egregore
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary

- Replaces multi-stage source build with single-stage image that downloads prebuilt binary from GitHub releases
- Supports `amd64`/`arm64` via Docker `TARGETARCH`
- Version pinnable via `EGREGORE_VERSION` build arg (defaults to `latest`)
- Simplifies `docker-compose.yml` build context — source checkout no longer needed

## Test plan

- [ ] `docker compose build` succeeds and downloads binary
- [ ] `docker compose up -d` starts node correctly
- [ ] `docker compose build --build-arg EGREGORE_VERSION=v1.1.0` pins version
- [ ] Container reports correct version via `/v1/status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)