### PR TITLE
chore: session save — prebuilt binary migration context

### DIFF
--- a/Memory/activeContext.md
+++ b/Memory/activeContext.md
@@ -1,0 +1,64 @@
+---
+version: "2.0"
+lastUpdated: "2026-02-28 UTC"
+lifecycle: "active"
+stakeholder: "all"
+changeTrigger: "Session save: prebuilt binary migration, source-free deployment"
+validatedBy: "user"
+dependencies: ["communicationStyle.md"]
+---
+
+# activeContext
+
+## Current Project Status
+
+**Primary Focus**: Egregore — decentralized knowledge sharing network for LLMs with gossip replication
+
+**Active Work**:
+- v1.1.0 running from `~/.local/bin/egregore` (prebuilt binary, self-update capable)
+- Claude Agent SDK hook (`~/.egregore/hooks/claude-disciplined-hook.py`) for mesh auto-response
+- Systemd-managed daemon with clean environment
+- Multi-node mesh operations (4 peers, 9 feeds, 1002 messages)
+- Source checkout no longer required to run the node
+
+**Recent Activities** (last 7 days):
+- **2026-02-28 (session 11)**: Migrated from source build to prebuilt binary. Installed v1.1.0 to `~/.local/bin/egregore`. Copied hooks to `~/.egregore/hooks/` with dedicated venv at `~/.egregore/venv/`. Updated systemd service and config.yaml to use new paths. Rewrote Dockerfile to download prebuilt binary from GitHub releases (PR #59, merged). Docker now independent of source checkout.
+- **2026-02-27 (session 10)**: Upgraded to v0.4.0 (push-based replication, relates/tags). Switched from bash watcher to `claude-disciplined-hook.py` using Claude Agent SDK. Installed Python 3.13 via asdf for SDK dependency. Removed hardcoded paths from all 5 example hook scripts (PR #34). Added `.claude/` to `.gitignore`. Broadcast `Lagged` fix merged (PR #28). End-to-end hook test confirmed working.
+- **2026-02-22 (session 9)**: Merged Docker example PR #16. Upgraded to v0.2.0. Systemd service. Author allowlist. Infra actions pipeline. Broadcast `Lagged` bug fix.
+
+## Key Learnings
+
+- **CLAUDECODE env var**: Propagates to child processes, prevents nested Claude. Fix: systemd `UnsetEnvironment` directive.
+- **Systemd user service**: Proper daemon management with `UnsetEnvironment=CLAUDECODE CLAUDE_CODE_ENTRYPOINT`. Replaces `nohup` approach.
+- **Broadcast channel `Lagged` bug**: `while let Ok(msg)` on `tokio::sync::broadcast::Receiver` exits the loop on `Lagged` errors, permanently killing hook processing. Must handle `Lagged` vs `Closed` explicitly.
+- **Claude Agent SDK hooks**: Python-based hooks using `claude-agent-sdk` package. Needs Python 3.10+ (installed 3.13 via asdf). Uses Claude Code credentials — no API key needed for Pro/Max. Execution discipline prompt distinguishes informational vs action queries.
+- **Portable shebangs**: Always `#!/usr/bin/env python3`. Never hardcode venv or system paths in committed scripts.
+- **Successful hook runs invisible at INFO**: Hook executor logs success at `debug` level. State file mtime is the best indicator of watcher activity.
+- **Firewall on UDM**: Use `~/Containers/unifi/udm-api.sh`, not local iptables/ufw.
+
+## Critical Reference Information
+
+- **Node binary**: `~/.local/bin/egregore` (prebuilt, self-update via `egregore update`)
+- **Node data**: `/home/pknull/egregore-data`
+- **Node identity**: `@+K6IB8+Zrk0/3tOxFyQDkrBbqDHeY20ARX4B9cJyxw0=.ed25519`
+- **Systemd service**: `~/.config/systemd/user/egregore.service` (enabled, auto-start)
+- **Hook scripts**: `~/.egregore/hooks/discord-notify.sh`, `~/.egregore/hooks/claude-disciplined-hook.py`
+- **Python venv**: `~/.egregore/venv/` (Python 3.13 via asdf, claude-agent-sdk + httpx)
+- **Docker files**: `~/.egregore/docker/` (Dockerfile, docker-compose.yml, config.yaml)
+- **Trusted authors**: lintop (`@7JIN8`), noctis (`@4epw+`), homebox2 (`@+K6IB`), docker relay (`@cL51n`)
+- **Discord webhook URL**: `~/.egregore/discord-webhook.url`
+- **UDM API**: `~/Containers/unifi/udm-api.sh`
+- **GitHub**: https://github.com/pknull/egregore (private)
+- **Daemon ports**: HTTP 7654, Gossip 7655
+
+## Next Steps
+
+**Immediate**:
+- [ ] Run `egregore update` to upgrade from v1.1.0 → v1.1.2
+- [ ] Test claude-disciplined-hook with a real query from another node
+- [ ] Consider adding `RUST_LOG=egregore::hooks=debug` to see successful hook completions
+
+**Deferred**:
+- Infra actions via hook (container lifecycle, firewall — requires expanding hook capabilities)
+- Firewall management tools (phase 3 — UDM port forwarding via mesh requests)
+- Rate limiting, feed pruning, Web UI

--- a/Memory/workflowProtocols.md
+++ b/Memory/workflowProtocols.md
@@ -1,0 +1,111 @@
+---
+version: "1.4"
+lastUpdated: "2026-02-28 UTC"
+lifecycle: "active"
+stakeholder: "technical"
+changeTrigger: "Prebuilt binary deployment, source-free node operation"
+validatedBy: "user"
+dependencies: ["activeContext.md", "techEnvironment.md"]
+---
+
+# workflowProtocols
+
+## Memory Location and Tool Scope
+
+- Memory path: `Memory/` (relative), `/home/pknull/Code/egregore/Memory/` (absolute)
+- Access rule: Read/Write tools for Memory files, Bash for git operations
+
+## Technical Verification
+
+- **Build**: `cargo build --release`
+- **Test**: `cargo test`
+- **Lint**: `cargo clippy`
+
+## Infrastructure Validation Protocol
+
+**BEFORE recommending new capabilities, commands, or infrastructure**:
+
+1. **Check existing infrastructure** against proposed enhancement
+2. **Compare proposed vs existing**: What's genuinely new?
+3. **Validate transferability**: Does this pattern work in our domain?
+
+**Pitfall**: Recommending duplicative infrastructure without checking existing capabilities.
+
+**Prevention**: Always ask "How does this compare to what we already have?"
+
+## Node Deployment Protocol
+
+**Binary update** (prebuilt):
+1. `egregore update` (self-update from GitHub releases)
+2. Restart service: `systemctl --user restart egregore`
+3. Verify: `systemctl --user status egregore` then `egregore_status` via MCP
+
+**From source** (development only):
+1. `cargo build --release`
+2. `cp target/release/egregore ~/.local/bin/egregore`
+3. Restart + verify as above
+
+**Systemd service**: `~/.config/systemd/user/egregore.service`
+- `ExecStart=%h/.local/bin/egregore --data-dir %h/egregore-data`
+- `UnsetEnvironment=CLAUDECODE CLAUDE_CODE_ENTRYPOINT` prevents nested Claude session errors
+- Enabled at login: `systemctl --user enable egregore`
+- Logs: `journalctl --user -u egregore -f`
+
+**Runtime layout** (independent of source checkout):
+- Binary: `~/.local/bin/egregore`
+- Hooks: `~/.egregore/hooks/`
+- Python venv: `~/.egregore/venv/`
+- Docker: `~/.egregore/docker/`
+- Data: `/home/pknull/egregore-data/`
+
+## Project-Specific Protocols
+
+- **Mesh operations**: Check feed via `egregore_query` before acting. Confirm destructive ops with operator.
+- **Firewall/UDM**: Use `~/Containers/unifi/udm-api.sh`, NOT local iptables/ufw.
+- **Webhook integrations**: Keep native `--hook-webhook-url` generic. Use `--hook-on-message` with formatting scripts for service-specific APIs.
+- **Multi-hook support**: Daemon config file supports multiple hook entries (no longer limited to one `--hook-on-message`).
+- **Infrastructure actions**: Watcher runs Claude from Containers project directory to inherit docker/firewall permissions. No custom MCP server needed.
+
+## Validated Patterns
+
+### Hook Dispatcher for Multiple Handlers
+
+**When to Use**: Need multiple actions on message arrival (Discord, Claude watcher, logging, etc.)
+**Process**: Single `on-message.sh` reads stdin, pipes to handlers in parallel via `&`, then `wait`
+**Why This Works**: Hook executor only supports one script path. Dispatcher provides fan-out without daemon changes.
+**Anti-Pattern**: Running multiple daemons or using cron alongside hooks.
+
+### Clean Env for Daemon Startup
+
+**When to Use**: Starting egregore from any Claude session (interactive or CI)
+**Process**: `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT nohup egregore ...`
+**Why This Works**: Claude sets `CLAUDECODE=1` in its process tree. Hook scripts that invoke Claude CLI detect this and refuse to run.
+**Anti-Pattern**: Starting daemon without stripping env, then debugging "nested session" errors in hook scripts.
+
+### Check the Mesh Before Acting
+
+**When to Use**: User references something happening "elsewhere" or mentions the other node
+**Process**: `egregore_query` with recent limit to see latest feed activity
+**Why This Works**: Peer nodes post status updates, feature proposals, and requests to the feed
+**Anti-Pattern**: Assuming full context without checking the mesh.
+
+### Hook Script PATH Requirements
+
+**When to Use**: Any hook script that calls tools not in /usr/bin
+**Process**: Export full PATH at top of script, including `~/.local/bin` and common tool paths
+**Why This Works**: Systemd service doesn't inherit user's interactive shell PATH
+**Anti-Pattern**: Assuming PATH is available, then getting exit 127 from missing `claude`, `jq`, etc.
+
+### Broadcast Channel Receiver Pattern
+
+**When to Use**: Any `tokio::sync::broadcast::Receiver` in a loop
+**Process**: Match on `Lagged` (log + continue) and `Closed` (break). Never use `while let Ok(msg)`.
+**Why This Works**: `Lagged` is recoverable — just means some messages were dropped. `Closed` means shutdown.
+**Anti-Pattern**: `while let Ok(msg) = rx.recv().await` — silently kills the receiver on buffer overflow.
+
+### Reuse Existing Project Permissions
+
+**When to Use**: Need Claude to perform privileged operations (docker, firewall, etc.)
+**Process**: Run Claude from a project directory that already has `settings.local.json` with the needed Bash permissions.
+**Why This Works**: Claude Code reads project-level settings including allowedTools. No need to build custom MCP servers.
+**Anti-Pattern**: Building new MCP servers or tool wrappers when permissions already exist in another project.


### PR DESCRIPTION
## Summary

- Add Memory/activeContext.md (v2.0) and Memory/workflowProtocols.md (v1.4)
- Documents migration from source build to prebuilt binary at ~/.local/bin/
- Updates deployment protocol, runtime layout, and hook/venv paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)