### PR TITLE
feat: folder-based custom schema persistence

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -273,6 +273,11 @@ impl Config {
         self.data_dir.join("egregore.db")
     }
 
+    /// Directory for custom schema definitions (.json files).
+    pub fn schemas_dir(&self) -> PathBuf {
+        self.data_dir.join("schemas")
+    }
+
     /// Build a FlowControlConfig from these settings.
     pub fn flow_control_config(&self) -> crate::gossip::flow_control::FlowControlConfig {
         crate::gossip::flow_control::FlowControlConfig {

--- a/src/feed/engine.rs
+++ b/src/feed/engine.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::Arc;
 
 use base64::engine::general_purpose::STANDARD as B64;
@@ -44,6 +45,17 @@ impl FeedEngine {
     /// In strict mode, messages without valid schemas are rejected.
     pub fn new_strict(store: FeedStore) -> Self {
         Self::with_schema_registry(store, SchemaRegistry::new(true))
+    }
+
+    /// Create a new feed engine with custom schemas from a directory.
+    /// Loads all `.json` schema files from the directory.
+    pub fn with_schemas_dir(store: FeedStore, schemas_dir: &Path) -> Self {
+        Self::with_schema_registry(store, SchemaRegistry::with_schemas_dir(false, schemas_dir))
+    }
+
+    /// Create a new feed engine with strict validation and custom schemas.
+    pub fn with_schemas_dir_strict(store: FeedStore, schemas_dir: &Path) -> Self {
+        Self::with_schema_registry(store, SchemaRegistry::with_schemas_dir(true, schemas_dir))
     }
 
     pub fn store(&self) -> &FeedStore {

--- a/src/feed/schema.rs
+++ b/src/feed/schema.rs
@@ -10,9 +10,49 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use crate::error::{EgreError, Result};
+
+/// Default message schema written when schemas directory is empty.
+const DEFAULT_MESSAGE_SCHEMA: &str = r#"{
+  "content_type": "message",
+  "version": 1,
+  "description": "Simple text message with optional title and metadata",
+  "codec": "json",
+  "compatibility": "backward",
+  "json_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["type", "text"],
+    "properties": {
+      "type": { "const": "message" },
+      "title": {
+        "type": ["string", "null"],
+        "description": "Optional title or subject"
+      },
+      "text": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The message body"
+      },
+      "format": {
+        "type": ["string", "null"],
+        "enum": [null, "plain", "markdown", "html"],
+        "description": "Text format hint"
+      },
+      "metadata": {
+        "type": ["object", "null"],
+        "description": "Arbitrary key-value metadata",
+        "additionalProperties": true
+      }
+    },
+    "additionalProperties": false
+  }
+}
+"#;
 
 /// Codec format for message serialization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -72,6 +112,26 @@ impl Default for CompatibilityMode {
     fn default() -> Self {
         Self::Backward
     }
+}
+
+/// Schema definition as stored in a file (without computed schema_id).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaFileDefinition {
+    /// Content type this schema validates (e.g., "insight").
+    pub content_type: String,
+    /// Schema version (monotonically increasing).
+    pub version: u32,
+    /// JSON Schema definition for validation.
+    pub json_schema: serde_json::Value,
+    /// Preferred codec for this schema.
+    #[serde(default)]
+    pub codec: Option<Codec>,
+    /// Compatibility mode for schema evolution.
+    #[serde(default)]
+    pub compatibility: Option<CompatibilityMode>,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 /// A schema definition with metadata.
@@ -183,6 +243,98 @@ impl SchemaRegistry {
         };
         registry.register_builtin_schemas();
         registry
+    }
+
+    /// Create a new schema registry and load custom schemas from a directory.
+    ///
+    /// Custom schemas are JSON files in the directory. Each file should contain
+    /// a SchemaDefinition-compatible structure:
+    /// ```json
+    /// {
+    ///   "content_type": "my_type",
+    ///   "version": 1,
+    ///   "json_schema": { ... },
+    ///   "codec": "json",
+    ///   "compatibility": "backward",
+    ///   "description": "Optional description"
+    /// }
+    /// ```
+    pub fn with_schemas_dir(strict_mode: bool, schemas_dir: &Path) -> Self {
+        let registry = Self::new(strict_mode);
+        registry.load_schemas_from_dir(schemas_dir);
+        registry
+    }
+
+    /// Load all `.json` schema files from a directory.
+    ///
+    /// Files are loaded in sorted order (alphabetically by filename).
+    /// If the directory is empty, a default `message.v1.json` schema is created.
+    /// Errors are logged but don't prevent other schemas from loading.
+    pub fn load_schemas_from_dir(&self, dir: &Path) {
+        // Create directory if it doesn't exist
+        if !dir.exists() {
+            if let Err(e) = fs::create_dir_all(dir) {
+                eprintln!("Failed to create schemas directory {:?}: {}", dir, e);
+                return;
+            }
+        }
+
+        let entries = match fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                eprintln!("Failed to read schemas directory {:?}: {}", dir, e);
+                return;
+            }
+        };
+
+        // Collect and sort entries for deterministic loading order
+        let mut paths: Vec<_> = entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().map_or(false, |ext| ext == "json"))
+            .collect();
+        paths.sort();
+
+        // If no schema files exist, create the default message schema
+        if paths.is_empty() {
+            let default_path = dir.join("message.v1.json");
+            if let Err(e) = fs::write(&default_path, DEFAULT_MESSAGE_SCHEMA) {
+                eprintln!("Failed to write default schema {:?}: {}", default_path, e);
+            } else {
+                paths.push(default_path);
+            }
+        }
+
+        for path in paths {
+            if let Err(e) = self.load_schema_file(&path) {
+                eprintln!("Failed to load schema from {:?}: {}", path, e);
+            }
+        }
+    }
+
+    /// Load a single schema file.
+    fn load_schema_file(&self, path: &Path) -> Result<()> {
+        let content = fs::read_to_string(path).map_err(|e| EgreError::Schema {
+            reason: format!("failed to read file: {}", e),
+        })?;
+
+        let file_def: SchemaFileDefinition =
+            serde_json::from_str(&content).map_err(|e| EgreError::Schema {
+                reason: format!("failed to parse JSON: {}", e),
+            })?;
+
+        let schema = SchemaDefinition {
+            schema_id: format!("{}/v{}", file_def.content_type, file_def.version),
+            content_type: file_def.content_type,
+            version: file_def.version,
+            json_schema: file_def.json_schema,
+            codec: file_def.codec.unwrap_or_default(),
+            compatibility: file_def.compatibility.unwrap_or_default(),
+            description: file_def.description,
+        };
+
+        self.register(schema)?;
+        Ok(())
     }
 
     /// Register built-in schemas for known content types.
@@ -884,5 +1036,52 @@ mod tests {
         let schema_ids: Vec<&str> = all.iter().map(|s| s.schema_id.as_str()).collect();
         assert!(schema_ids.contains(&"insight/v1"));
         assert!(schema_ids.contains(&"profile/v1"));
+    }
+
+    #[test]
+    fn load_schemas_from_empty_dir_creates_default() {
+        let temp_dir = std::env::temp_dir().join(format!("egregore_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp_dir); // Clean up if exists
+
+        let registry = SchemaRegistry::with_schemas_dir(false, &temp_dir);
+
+        // Should have created the default message schema
+        assert!(registry.get("message/v1").is_some());
+
+        // File should exist
+        assert!(temp_dir.join("message.v1.json").exists());
+
+        // Clean up
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn load_schemas_from_dir_with_custom_schema() {
+        let temp_dir = std::env::temp_dir().join(format!("egregore_test_custom_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        // Write a custom schema
+        let custom_schema = r#"{
+            "content_type": "test_custom",
+            "version": 1,
+            "json_schema": {
+                "type": "object",
+                "required": ["type"],
+                "properties": { "type": { "const": "test_custom" } }
+            }
+        }"#;
+        std::fs::write(temp_dir.join("test_custom.v1.json"), custom_schema).unwrap();
+
+        let registry = SchemaRegistry::with_schemas_dir(false, &temp_dir);
+
+        // Should have loaded the custom schema
+        assert!(registry.get("test_custom/v1").is_some());
+
+        // Should NOT have created default (directory wasn't empty)
+        assert!(!temp_dir.join("message.v1.json").exists());
+
+        // Clean up
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,12 +350,14 @@ async fn main() -> anyhow::Result<()> {
         Err(e) => tracing::warn!(error = %e, "failed to increment generation counter"),
     }
 
+    let schemas_dir = config.schemas_dir();
     let engine = if config.schema_strict {
         tracing::info!("strict schema validation enabled");
-        Arc::new(FeedEngine::new_strict(store))
+        Arc::new(FeedEngine::with_schemas_dir_strict(store, &schemas_dir))
     } else {
-        Arc::new(FeedEngine::new(store))
+        Arc::new(FeedEngine::with_schemas_dir(store, &schemas_dir))
     };
+    tracing::info!(schemas_dir = %schemas_dir.display(), "custom schemas directory");
 
     // Start hook executor if configured
     if let Some(executor) = HookExecutor::new(config.hooks.clone()) {


### PR DESCRIPTION
## Summary

- Custom schemas can now be loaded from JSON files in `data_dir/schemas/`
- Schemas persist across restarts (previously lost on restart)
- Auto-creates default `message.v1.json` if schemas directory is empty
- Default message schema supports: type, title, text, format, metadata

## Changes

- `SchemaRegistry::with_schemas_dir()` - load schemas from folder
- `FeedEngine::with_schemas_dir()` / `with_schemas_dir_strict()` - engine constructors
- `Config::schemas_dir()` - helper for schemas path
- Auto-create default schema when folder is empty

## Test plan

- [x] `cargo test load_schemas_from` - folder loading tests pass
- [x] `cargo test schema` - all schema tests pass
- [ ] Manual: start node, verify `~/.config/egregore/schemas/message.v1.json` created
- [ ] Manual: add custom schema file, restart, verify loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)