### PR TITLE
Bump crate version to 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "egregore"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name = "egregore"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "SSB-inspired decentralized knowledge sharing for LLMs"
 license = "MIT"


### PR DESCRIPTION
Version bump for file-based schemas.