### PR TITLE
fix(api): require Content-Type: application/json on mutating endpoints (CSRF mitigation)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -87,7 +87,7 @@ async fn require_json_content_type(req: Request<Body>, next: Next) -> Response {
                     "UNSUPPORTED_MEDIA_TYPE",
                     "Content-Type must be application/json for mutating requests",
                 )
-                    .into_response();
+                .into_response();
             }
         }
     }
@@ -182,9 +182,9 @@ pub fn router_with_mcp(state: AppState, mcp_enabled: bool) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::http::Request;
     use crate::feed::engine::FeedEngine;
     use crate::feed::store::FeedStore;
+    use axum::http::Request;
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
@@ -211,7 +211,9 @@ mod tests {
         let req = Request::builder()
             .method("POST")
             .uri("/v1/publish")
-            .body(Body::from(r#"{"content":{"type":"message","text":"pwned"}}"#))
+            .body(Body::from(
+                r#"{"content":{"type":"message","text":"pwned"}}"#,
+            ))
             .unwrap();
 
         let resp = app.oneshot(req).await.unwrap();
@@ -252,7 +254,9 @@ mod tests {
             .method("POST")
             .uri("/v1/publish")
             .header("content-type", "application/json")
-            .body(Body::from(r#"{"content":{"type":"message","text":"test"}}"#))
+            .body(Body::from(
+                r#"{"content":{"type":"message","text":"test"}}"#,
+            ))
             .unwrap();
 
         let resp = app.oneshot(req).await.unwrap();


### PR DESCRIPTION
## Summary

Adds CSRF protection to the HTTP API by requiring `Content-Type: application/json` for mutating requests (`POST`, `PUT`, `DELETE`, `PATCH`).

### The Vulnerability

While the API binds to localhost only, browser-based CSRF attacks can still reach it:

```html
<form action="http://localhost:7654/v1/publish" method="POST">
  <input name="content" value='{"type":"message","text":"pwned"}'>
</form>
<script>document.forms[0].submit()</script>
```

A malicious webpage could publish messages, add peers, or modify follows on behalf of a local user.

### The Fix

Middleware rejects mutating requests without `Content-Type: application/json`:

- HTML forms can only send `application/x-www-form-urlencoded` or `multipart/form-data`
- JavaScript `fetch()` with custom headers triggers CORS preflight, which fails cross-origin to localhost
- Legitimate API clients already send `application/json`

Returns `415 Unsupported Media Type` with standard error envelope for non-compliant requests.

### Compatibility

This is not a breaking change for legitimate JSON API clients.

## Test Plan

- [x] `csrf_rejects_post_without_content_type`
- [x] `csrf_rejects_post_with_form_content_type`
- [x] `csrf_allows_post_with_json_content_type`
- [x] `csrf_allows_get_without_content_type`
- [x] `csrf_rejects_delete_without_content_type`
- [x] Existing tests pass

## Tracking

Fixes #90

Split context:
- Parent: #70
- Remaining auth work: #88 and #89