### PR TITLE
fix(gossip): change to fail-closed policy on follows read error

### DIFF
--- a/src/gossip/client.rs
+++ b/src/gossip/client.rs
@@ -271,12 +271,29 @@ pub(crate) async fn build_replication_config(engine: &Arc<FeedEngine>) -> Replic
             }
         }
         Ok((Err(e), _)) => {
-            tracing::warn!(error = %e, "failed to read follows, replicating all feeds");
-            ReplicationConfig::default()
+            // FAIL-CLOSED: Don't widen scope on error. Use empty follows set.
+            // This prevents unintended broad replication when storage fails.
+            tracing::error!(
+                error = %e,
+                "failed to read follows, using fail-closed policy (no replication)"
+            );
+            ReplicationConfig {
+                follows: Some(std::collections::HashSet::new()), // Empty = replicate no one
+                topics: None,
+                bloom_config: BloomConfig::default(),
+            }
         }
         Err(e) => {
-            tracing::warn!(error = %e, "config task failed, replicating all feeds");
-            ReplicationConfig::default()
+            // FAIL-CLOSED: Task panic should not expand scope.
+            tracing::error!(
+                error = %e,
+                "replication config task failed, using fail-closed policy (no replication)"
+            );
+            ReplicationConfig {
+                follows: Some(std::collections::HashSet::new()), // Empty = replicate no one
+                topics: None,
+                bloom_config: BloomConfig::default(),
+            }
         }
     }
 }
@@ -429,5 +446,76 @@ async fn update_peer_health(engine: &Arc<FeedEngine>, peer_addr: &str, remote_id
     .await
     {
         tracing::warn!(error = %e, "peer sync update task failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::PublicId;
+
+    /// Verify that a ReplicationConfig with empty follows set rejects all authors.
+    /// This is the fail-closed behavior - replicate no one.
+    #[test]
+    fn fail_closed_config_rejects_all_authors() {
+        let config = ReplicationConfig {
+            follows: Some(std::collections::HashSet::new()), // Empty = no one
+            topics: None,
+            bloom_config: BloomConfig::default(),
+        };
+
+        // Should reject any author since follows is empty
+        let test_author = PublicId("@TEST123.ed25519".to_string());
+        assert!(
+            !config.wants_author(&test_author),
+            "fail-closed config should reject all authors"
+        );
+    }
+
+    /// Verify that default config (None follows) accepts all authors.
+    /// This is fail-open behavior we want to avoid on errors.
+    #[test]
+    fn default_config_accepts_all_authors() {
+        let config = ReplicationConfig::default();
+
+        // Should accept any author since follows is None
+        let test_author = PublicId("@TEST123.ed25519".to_string());
+        assert!(
+            config.wants_author(&test_author),
+            "default config should accept all authors"
+        );
+    }
+
+    /// Verify distinction between None (all) and Some(empty) (none).
+    #[test]
+    fn none_vs_empty_follows_semantics() {
+        let test_author = PublicId("@TEST123.ed25519".to_string());
+
+        // None means "replicate all" (no filter)
+        let all_config = ReplicationConfig {
+            follows: None,
+            topics: None,
+            bloom_config: BloomConfig::default(),
+        };
+        assert!(all_config.wants_author(&test_author));
+
+        // Some(empty) means "replicate none" (filter, but empty list)
+        let none_config = ReplicationConfig {
+            follows: Some(std::collections::HashSet::new()),
+            topics: None,
+            bloom_config: BloomConfig::default(),
+        };
+        assert!(!none_config.wants_author(&test_author));
+
+        // Some with entries means "replicate only these"
+        let mut follows = std::collections::HashSet::new();
+        follows.insert(test_author.clone());
+        let selective_config = ReplicationConfig {
+            follows: Some(follows),
+            topics: None,
+            bloom_config: BloomConfig::default(),
+        };
+        assert!(selective_config.wants_author(&test_author));
+        assert!(!selective_config.wants_author(&PublicId("@OTHER.ed25519".to_string())));
     }
 }

--- a/src/gossip/replication.rs
+++ b/src/gossip/replication.rs
@@ -111,7 +111,7 @@ pub struct ReplicationConfig {
 
 impl ReplicationConfig {
     /// Check if we want messages from this author.
-    fn wants_author(&self, author: &PublicId) -> bool {
+    pub(crate) fn wants_author(&self, author: &PublicId) -> bool {
         match &self.follows {
             Some(follows) => follows.contains(author),
             None => true,


### PR DESCRIPTION
## Summary

Fixes #75 - Remove fail-open replication scope on follows read errors.

### Problem

When follows retrieval failed (storage error), replication scope widened to all feeds:

```rust
// Before: fail-open
Ok((Err(e), _)) => {
    tracing::warn!(error = %e, "failed to read follows, replicating all feeds");
    ReplicationConfig::default()  // follows: None = replicate ALL
}
```

This violates operator expectations for selective replication boundaries.

### Solution

Change to fail-closed policy - on error, replicate no one:

```rust
// After: fail-closed
Ok((Err(e), _)) => {
    tracing::error!(
        error = %e,
        "failed to read follows, using fail-closed policy (no replication)"
    );
    ReplicationConfig {
        follows: Some(HashSet::new()),  // Empty = replicate NO ONE
        topics: None,
        bloom_config: BloomConfig::default(),
    }
}
```

### Semantics

| `follows` value | Behavior |
|-----------------|----------|
| `None` | No filter, replicate all feeds |
| `Some(empty)` | Filter active, replicate no feeds |
| `Some(set)` | Filter active, replicate only set members |

### Tests Added

- `fail_closed_config_rejects_all_authors`: Verifies empty set rejects all
- `default_config_accepts_all_authors`: Verifies None accepts all
- `none_vs_empty_follows_semantics`: Documents the distinction

## Test Plan

- [x] `cargo test gossip::client::` - 3 new tests pass
- [x] `cargo test` - Full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)