### PR TITLE
chore: hygiene and consistency cleanup

### DIFF
--- a/src/feed/schema.rs
+++ b/src/feed/schema.rs
@@ -14,12 +14,16 @@ use std::fs;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
+use tracing;
+
 use crate::error::{EgreError, Result};
 
 /// Default schemas written when schemas directory is empty.
 /// All schemas are file-based - nothing is compiled in.
 const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
-    ("message.v1.json", r#"{
+    (
+        "message.v1.json",
+        r#"{
   "content_type": "message",
   "version": 1,
   "description": "Simple text message with optional title and metadata",
@@ -38,8 +42,11 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
     },
     "additionalProperties": false
   }
-}"#),
-    ("insight.v1.json", r#"{
+}"#,
+    ),
+    (
+        "insight.v1.json",
+        r#"{
   "content_type": "insight",
   "version": 1,
   "description": "Observation with optional evidence and guidance",
@@ -61,8 +68,11 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
     },
     "additionalProperties": false
   }
-}"#),
-    ("endorsement.v1.json", r#"{
+}"#,
+    ),
+    (
+        "endorsement.v1.json",
+        r#"{
   "content_type": "endorsement",
   "version": 1,
   "description": "Endorsement of another message",
@@ -79,8 +89,11 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
     },
     "additionalProperties": false
   }
-}"#),
-    ("dispute.v1.json", r#"{
+}"#,
+    ),
+    (
+        "dispute.v1.json",
+        r#"{
   "content_type": "dispute",
   "version": 1,
   "description": "Dispute of another message with reason",
@@ -98,8 +111,11 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
     },
     "additionalProperties": false
   }
-}"#),
-    ("query.v1.json", r#"{
+}"#,
+    ),
+    (
+        "query.v1.json",
+        r#"{
   "content_type": "query",
   "version": 1,
   "description": "Question to the mesh",
@@ -117,8 +133,11 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
     },
     "additionalProperties": false
   }
-}"#),
-    ("response.v1.json", r#"{
+}"#,
+    ),
+    (
+        "response.v1.json",
+        r#"{
   "content_type": "response",
   "version": 1,
   "description": "Response to a query",
@@ -137,8 +156,11 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
     },
     "additionalProperties": false
   }
-}"#),
-    ("profile.v1.json", r#"{
+}"#,
+    ),
+    (
+        "profile.v1.json",
+        r#"{
   "content_type": "profile",
   "version": 1,
   "description": "Agent profile information",
@@ -156,7 +178,8 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
     },
     "additionalProperties": false
   }
-}"#),
+}"#,
+    ),
 ];
 
 /// Codec format for message serialization.
@@ -377,7 +400,7 @@ impl SchemaRegistry {
         // Create directory if it doesn't exist
         if !dir.exists() {
             if let Err(e) = fs::create_dir_all(dir) {
-                eprintln!("Failed to create schemas directory {:?}: {}", dir, e);
+                tracing::warn!(dir = ?dir, error = %e, "failed to create schemas directory");
                 return;
             }
         }
@@ -385,7 +408,7 @@ impl SchemaRegistry {
         let entries = match fs::read_dir(dir) {
             Ok(entries) => entries,
             Err(e) => {
-                eprintln!("Failed to read schemas directory {:?}: {}", dir, e);
+                tracing::warn!(dir = ?dir, error = %e, "failed to read schemas directory");
                 return;
             }
         };
@@ -394,7 +417,7 @@ impl SchemaRegistry {
         let mut paths: Vec<_> = entries
             .filter_map(|e| e.ok())
             .map(|e| e.path())
-            .filter(|p| p.extension().map_or(false, |ext| ext == "json"))
+            .filter(|p| p.extension().is_some_and(|ext| ext == "json"))
             .collect();
         paths.sort();
 
@@ -403,7 +426,7 @@ impl SchemaRegistry {
             for (filename, content) in DEFAULT_SCHEMAS {
                 let schema_path = dir.join(filename);
                 if let Err(e) = fs::write(&schema_path, content) {
-                    eprintln!("Failed to write default schema {:?}: {}", schema_path, e);
+                    tracing::warn!(path = ?schema_path, error = %e, "failed to write default schema");
                 } else {
                     paths.push(schema_path);
                 }
@@ -412,7 +435,7 @@ impl SchemaRegistry {
 
         for path in paths {
             if let Err(e) = self.load_schema_file(&path) {
-                eprintln!("Failed to load schema from {:?}: {}", path, e);
+                tracing::warn!(path = ?path, error = %e, "failed to load schema");
             }
         }
     }
@@ -1054,7 +1077,8 @@ mod tests {
 
     #[test]
     fn load_schemas_from_dir_with_custom_schema() {
-        let temp_dir = std::env::temp_dir().join(format!("egregore_test_custom_{}", std::process::id()));
+        let temp_dir =
+            std::env::temp_dir().join(format!("egregore_test_custom_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&temp_dir);
         std::fs::create_dir_all(&temp_dir).unwrap();
 

--- a/src/gossip/discovery.rs
+++ b/src/gossip/discovery.rs
@@ -85,7 +85,7 @@ pub async fn run_discovery(
     // Announce loop
     let broadcast_addr: SocketAddr = format!("255.255.255.255:{}", config.discovery_port)
         .parse()
-        .unwrap();
+        .expect("broadcast address with valid port should always parse");
 
     let announcement = Announcement {
         magic: *MAGIC,


### PR DESCRIPTION
## Summary

- Apply rustfmt formatting to schema.rs (array literal formatting)
- Fix clippy warning: `map_or(false, ...)` → `is_some_and(...)`
- Replace `eprintln!` with `tracing::warn!` in schema loader for structured logging
- Replace runtime `unwrap()` with `expect()` in discovery startup for clearer panic messages

## Design

All changes are mechanical hygiene fixes:
- No behavior changes
- No new dependencies
- No API changes

MCP tool-count documentation was verified (11 tools listed in both README.md and operations.md, matching actual implementation).

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` all tests pass

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)