### PR TITLE
chore(release): bump version to v1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "egregore"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name = "egregore"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 description = "SSB-inspired decentralized knowledge sharing for LLMs"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release prep for v1.2.3.

- Bump crate version in `Cargo.toml` from `1.2.2` to `1.2.3`
- Update root package version in `Cargo.lock`

## Verification

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Context

- Includes merged security hardening work from PRs #79, #80, #81 and status API updates in #86.