### PR TITLE
feat: return structured API validation errors

### DIFF
--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -1,3 +1,4 @@
+use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -17,6 +18,14 @@ pub struct ApiResponse<T: Serialize> {
 #[derive(Serialize)]
 pub struct ApiError {
     pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Vec<ApiValidationDetail>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ApiValidationDetail {
+    pub field: String,
     pub message: String,
 }
 
@@ -53,6 +62,24 @@ pub fn err<T: Serialize>(
     code: &str,
     message: &str,
 ) -> (StatusCode, Json<ApiResponse<T>>) {
+    err_with_details(status, code, message, None)
+}
+
+pub fn err_with_detail<T: Serialize>(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+    detail: ApiValidationDetail,
+) -> (StatusCode, Json<ApiResponse<T>>) {
+    err_with_details(status, code, message, Some(vec![detail]))
+}
+
+pub fn err_with_details<T: Serialize>(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+    details: Option<Vec<ApiValidationDetail>>,
+) -> (StatusCode, Json<ApiResponse<T>>) {
     (
         status,
         Json(ApiResponse {
@@ -61,10 +88,76 @@ pub fn err<T: Serialize>(
             error: Some(ApiError {
                 code: code.to_string(),
                 message: message.to_string(),
+                details,
             }),
             metadata: None,
         }),
     )
+}
+
+pub fn validation_detail(
+    field: impl Into<String>,
+    message: impl Into<String>,
+) -> ApiValidationDetail {
+    ApiValidationDetail {
+        field: field.into(),
+        message: message.into(),
+    }
+}
+
+pub fn json_rejection<T: Serialize>(
+    rejection: JsonRejection,
+) -> (StatusCode, Json<ApiResponse<T>>) {
+    let status = rejection.status();
+    let body_text = rejection.body_text();
+
+    let (code, message) = match &rejection {
+        JsonRejection::JsonSyntaxError(_) => {
+            ("INVALID_JSON_BODY", "request body is not valid JSON")
+        }
+        JsonRejection::JsonDataError(_) => ("INVALID_JSON_BODY", "request body failed validation"),
+        JsonRejection::MissingJsonContentType(_) => (
+            "UNSUPPORTED_MEDIA_TYPE",
+            "Content-Type must be application/json for mutating requests",
+        ),
+        _ => ("INVALID_JSON_BODY", "request body could not be processed"),
+    };
+
+    let detail = validation_detail(
+        extract_json_field_name(&body_text).unwrap_or_else(|| "body".to_string()),
+        normalize_json_rejection_message(&body_text),
+    );
+
+    err_with_detail(status, code, message, detail)
+}
+
+fn normalize_json_rejection_message(message: &str) -> String {
+    const PREFIXES: [&str; 4] = [
+        "Failed to deserialize the JSON body into the target type: ",
+        "Failed to parse the request body as JSON: ",
+        "Failed to buffer the request body: ",
+        "Request body didn't contain valid UTF-8: ",
+    ];
+
+    for prefix in PREFIXES {
+        if let Some(stripped) = message.strip_prefix(prefix) {
+            return stripped.to_string();
+        }
+    }
+
+    message.to_string()
+}
+
+fn extract_json_field_name(message: &str) -> Option<String> {
+    for marker in ["missing field `", "unknown field `", "duplicate field `"] {
+        if let Some(rest) = message.split(marker).nth(1) {
+            if let Some(field) = rest.split('`').next() {
+                return Some(field.to_string());
+            }
+        }
+    }
+
+    None
 }
 
 pub fn from_error(e: crate::error::EgreError) -> Response {
@@ -102,6 +195,7 @@ pub fn from_error(e: crate::error::EgreError) -> Response {
         error: Some(ApiError {
             code: code.to_string(),
             message,
+            details: None,
         }),
         metadata: None,
     });

--- a/src/api/routes_groups.rs
+++ b/src/api/routes_groups.rs
@@ -25,6 +25,7 @@
 //! - GET /v1/groups/:id/offsets - Get group offsets
 //! - POST /v1/groups/:id/offsets - Commit an offset
 
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -158,13 +159,22 @@ fn is_valid_group_id(group_id: &str) -> bool {
 /// POST /v1/groups - Create a new consumer group.
 pub async fn create_group(
     State(state): State<AppState>,
-    Json(req): Json<CreateGroupRequest>,
+    payload: Result<Json<CreateGroupRequest>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => return response::json_rejection::<GroupInfo>(rejection).into_response(),
+    };
+
     if !is_valid_group_id(&req.group_id) {
-        return response::err::<GroupInfo>(
+        return response::err_with_detail::<GroupInfo>(
             StatusCode::BAD_REQUEST,
             "INVALID_GROUP_ID",
             "group_id must be 1-64 alphanumeric characters, hyphens, or underscores",
+            response::validation_detail(
+                "group_id",
+                "must be 1-64 alphanumeric characters, hyphens, or underscores",
+            ),
         )
         .into_response();
     }
@@ -353,22 +363,34 @@ pub async fn get_group_members(
 pub async fn join_group(
     State(state): State<AppState>,
     Path(group_id): Path<String>,
-    Json(req): Json<JoinGroupRequest>,
+    payload: Result<Json<JoinGroupRequest>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => {
+            return response::json_rejection::<JoinGroupResponse>(rejection).into_response();
+        }
+    };
+
     if !PublicId::is_valid_format(&req.member_id) {
-        return response::err::<JoinGroupResponse>(
+        return response::err_with_detail::<JoinGroupResponse>(
             StatusCode::BAD_REQUEST,
             "INVALID_MEMBER_ID",
             "member_id must be in @<base64>.ed25519 format",
+            response::validation_detail("member_id", "must be in @<base64>.ed25519 format"),
         )
         .into_response();
     }
 
     if !is_valid_group_id(&group_id) {
-        return response::err::<JoinGroupResponse>(
+        return response::err_with_detail::<JoinGroupResponse>(
             StatusCode::BAD_REQUEST,
             "INVALID_GROUP_ID",
             "group_id must be 1-64 alphanumeric characters, hyphens, or underscores",
+            response::validation_detail(
+                "group_id",
+                "must be 1-64 alphanumeric characters, hyphens, or underscores",
+            ),
         )
         .into_response();
     }
@@ -399,13 +421,19 @@ pub async fn join_group(
 pub async fn leave_group(
     State(state): State<AppState>,
     Path(group_id): Path<String>,
-    Json(req): Json<LeaveGroupRequest>,
+    payload: Result<Json<LeaveGroupRequest>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => return response::json_rejection::<()>(rejection).into_response(),
+    };
+
     if !PublicId::is_valid_format(&req.member_id) {
-        return response::err::<()>(
+        return response::err_with_detail::<()>(
             StatusCode::BAD_REQUEST,
             "INVALID_MEMBER_ID",
             "member_id must be in @<base64>.ed25519 format",
+            response::validation_detail("member_id", "must be in @<base64>.ed25519 format"),
         )
         .into_response();
     }
@@ -477,22 +505,29 @@ pub async fn get_group_offsets(
 pub async fn commit_offset(
     State(state): State<AppState>,
     Path(group_id): Path<String>,
-    Json(req): Json<CommitOffsetRequest>,
+    payload: Result<Json<CommitOffsetRequest>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => return response::json_rejection::<OffsetInfo>(rejection).into_response(),
+    };
+
     if !PublicId::is_valid_format(&req.author) {
-        return response::err::<OffsetInfo>(
+        return response::err_with_detail::<OffsetInfo>(
             StatusCode::BAD_REQUEST,
             "INVALID_AUTHOR",
             "author must be in @<base64>.ed25519 format",
+            response::validation_detail("author", "must be in @<base64>.ed25519 format"),
         )
         .into_response();
     }
 
     if !PublicId::is_valid_format(&req.committed_by) {
-        return response::err::<OffsetInfo>(
+        return response::err_with_detail::<OffsetInfo>(
             StatusCode::BAD_REQUEST,
             "INVALID_COMMITTED_BY",
             "committed_by must be in @<base64>.ed25519 format",
+            response::validation_detail("committed_by", "must be in @<base64>.ed25519 format"),
         )
         .into_response();
     }

--- a/src/api/routes_peers.rs
+++ b/src/api/routes_peers.rs
@@ -1,3 +1,4 @@
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -125,13 +126,19 @@ pub async fn get_peers(State(state): State<AppState>) -> impl IntoResponse {
 
 pub async fn add_peer(
     State(state): State<AppState>,
-    Json(req): Json<AddPeerRequest>,
+    payload: Result<Json<AddPeerRequest>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => return response::json_rejection::<PeerInfo>(rejection).into_response(),
+    };
+
     if !is_valid_peer_address(&req.address) {
-        return response::err::<PeerInfo>(
+        return response::err_with_detail::<PeerInfo>(
             StatusCode::BAD_REQUEST,
             "INVALID_ADDRESS",
             "address must be in host:port format",
+            response::validation_detail("address", "must be in host:port format"),
         )
         .into_response();
     }
@@ -167,10 +174,11 @@ pub async fn delete_peer(
     Path(address): Path<String>,
 ) -> impl IntoResponse {
     if !is_valid_peer_address(&address) {
-        return response::err::<()>(
+        return response::err_with_detail::<()>(
             StatusCode::BAD_REQUEST,
             "INVALID_ADDRESS",
             "address must be in host:port format",
+            response::validation_detail("address", "must be in host:port format"),
         )
         .into_response();
     }

--- a/src/api/routes_publish.rs
+++ b/src/api/routes_publish.rs
@@ -4,6 +4,7 @@
 //! the node's Ed25519 key, chains to the previous message, and stores it.
 //! The message propagates to peers on the next gossip cycle.
 
+use axum::extract::rejection::JsonRejection;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -35,8 +36,13 @@ pub struct PublishRequest {
 
 pub async fn publish(
     State(state): State<AppState>,
-    Json(req): Json<PublishRequest>,
+    payload: Result<Json<PublishRequest>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => return response::json_rejection::<()>(rejection).into_response(),
+    };
+
     let identity = state.identity.clone();
     let engine = state.engine.clone();
 

--- a/src/api/routes_retention.rs
+++ b/src/api/routes_retention.rs
@@ -1,5 +1,6 @@
 //! Retention policy API routes.
 
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -145,16 +146,68 @@ pub async fn list_policies(State(state): State<AppState>) -> impl IntoResponse {
 /// Create a retention policy.
 pub async fn create_policy(
     State(state): State<AppState>,
-    Json(req): Json<CreatePolicyRequest>,
+    payload: Result<Json<CreatePolicyRequest>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => {
+            return response::json_rejection::<PolicyResponse>(rejection).into_response()
+        }
+    };
+
     // Validate scope
     let scope = match req.scope.to_retention_scope() {
         Ok(s) => s,
         Err(msg) => {
-            return response::err::<()>(StatusCode::BAD_REQUEST, "INVALID_SCOPE", msg)
-                .into_response()
+            return response::err_with_detail::<PolicyResponse>(
+                StatusCode::BAD_REQUEST,
+                "INVALID_SCOPE",
+                msg,
+                response::validation_detail("scope", msg),
+            )
+            .into_response()
         }
     };
+
+    if matches!(req.max_age_secs, Some(0)) {
+        return response::err_with_detail::<PolicyResponse>(
+            StatusCode::BAD_REQUEST,
+            "INVALID_MAX_AGE_SECS",
+            "max_age_secs must be greater than 0",
+            response::validation_detail("max_age_secs", "must be greater than 0"),
+        )
+        .into_response();
+    }
+
+    if matches!(req.max_count, Some(0)) {
+        return response::err_with_detail::<PolicyResponse>(
+            StatusCode::BAD_REQUEST,
+            "INVALID_MAX_COUNT",
+            "max_count must be greater than 0",
+            response::validation_detail("max_count", "must be greater than 0"),
+        )
+        .into_response();
+    }
+
+    if matches!(req.max_bytes, Some(0)) {
+        return response::err_with_detail::<PolicyResponse>(
+            StatusCode::BAD_REQUEST,
+            "INVALID_MAX_BYTES",
+            "max_bytes must be greater than 0",
+            response::validation_detail("max_bytes", "must be greater than 0"),
+        )
+        .into_response();
+    }
+
+    if matches!(req.compact_key.as_deref(), Some(key) if key.trim().is_empty()) {
+        return response::err_with_detail::<PolicyResponse>(
+            StatusCode::BAD_REQUEST,
+            "INVALID_COMPACT_KEY",
+            "compact_key must be a non-empty string when provided",
+            response::validation_detail("compact_key", "must be a non-empty string when provided"),
+        )
+        .into_response();
+    }
 
     // Require at least one retention criterion
     if req.max_age_secs.is_none()
@@ -162,10 +215,14 @@ pub async fn create_policy(
         && req.max_bytes.is_none()
         && req.compact_key.is_none()
     {
-        return response::err::<()>(
+        return response::err_with_detail::<PolicyResponse>(
             StatusCode::BAD_REQUEST,
             "MISSING_CRITERION",
             "policy must have at least one of: max_age_secs, max_count, max_bytes, compact_key",
+            response::validation_detail(
+                "policy",
+                "must include at least one of: max_age_secs, max_count, max_bytes, compact_key",
+            ),
         )
         .into_response();
     }

--- a/src/api/routes_schema.rs
+++ b/src/api/routes_schema.rs
@@ -3,6 +3,7 @@
 //! Provides endpoints for listing registered schemas, getting schema details,
 //! and registering custom schemas.
 
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -120,9 +121,45 @@ pub async fn get_schema(
 /// POST /v1/schemas - Register a new schema.
 pub async fn register_schema(
     State(state): State<AppState>,
-    Json(req): Json<RegisterSchemaRequest>,
+    payload: Result<Json<RegisterSchemaRequest>, JsonRejection>,
 ) -> impl IntoResponse {
-    let mut schema = SchemaDefinition::new(req.content_type, req.version, req.json_schema);
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => return response::json_rejection::<SchemaInfo>(rejection).into_response(),
+    };
+
+    let content_type = req.content_type.trim();
+    if content_type.is_empty() {
+        return response::err_with_detail::<SchemaInfo>(
+            StatusCode::BAD_REQUEST,
+            "INVALID_CONTENT_TYPE",
+            "content_type must be a non-empty string",
+            response::validation_detail("content_type", "must be a non-empty string"),
+        )
+        .into_response();
+    }
+
+    if req.version == 0 {
+        return response::err_with_detail::<SchemaInfo>(
+            StatusCode::BAD_REQUEST,
+            "INVALID_VERSION",
+            "version must be greater than 0",
+            response::validation_detail("version", "must be greater than 0"),
+        )
+        .into_response();
+    }
+
+    if !req.json_schema.is_object() {
+        return response::err_with_detail::<SchemaInfo>(
+            StatusCode::BAD_REQUEST,
+            "INVALID_JSON_SCHEMA",
+            "json_schema must be a JSON object",
+            response::validation_detail("json_schema", "must be a JSON object"),
+        )
+        .into_response();
+    }
+
+    let mut schema = SchemaDefinition::new(content_type.to_string(), req.version, req.json_schema);
 
     if let Some(codec) = req.codec {
         schema = schema.with_codec(codec);
@@ -143,8 +180,30 @@ pub async fn register_schema(
 /// POST /v1/schemas/validate - Validate content against a schema.
 pub async fn validate_content(
     State(state): State<AppState>,
-    Json(req): Json<ValidateRequest>,
+    payload: Result<Json<ValidateRequest>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(req) = match payload {
+        Ok(req) => req,
+        Err(rejection) => {
+            return response::json_rejection::<ValidateResponse>(rejection).into_response();
+        }
+    };
+
+    if let Some(schema_id) = req.schema_id.as_deref() {
+        if schema_id.trim().is_empty() {
+            return response::err_with_detail::<ValidateResponse>(
+                StatusCode::BAD_REQUEST,
+                "INVALID_SCHEMA_ID",
+                "schema_id must be a non-empty string when provided",
+                response::validation_detail(
+                    "schema_id",
+                    "must be a non-empty string when provided",
+                ),
+            )
+            .into_response();
+        }
+    }
+
     let registry = state.engine.schema_registry();
 
     // Determine effective schema_id

--- a/src/api/routes_topics.rs
+++ b/src/api/routes_topics.rs
@@ -32,10 +32,11 @@ pub async fn add_topic_subscription(
 ) -> impl IntoResponse {
     let trimmed = topic.trim();
     if trimmed.is_empty() || trimmed.len() > 256 {
-        return response::err::<TopicInfo>(
+        return response::err_with_detail::<TopicInfo>(
             StatusCode::BAD_REQUEST,
             "INVALID_TOPIC",
             "topic must be 1-256 characters",
+            response::validation_detail("topic", "must be 1-256 characters"),
         )
         .into_response();
     }
@@ -70,10 +71,23 @@ pub async fn remove_topic_subscription(
     State(state): State<AppState>,
     Path(topic): Path<String>,
 ) -> impl IntoResponse {
+    let trimmed = topic.trim();
+    if trimmed.is_empty() || trimmed.len() > 256 {
+        return response::err_with_detail::<()>(
+            StatusCode::BAD_REQUEST,
+            "INVALID_TOPIC",
+            "topic must be 1-256 characters",
+            response::validation_detail("topic", "must be 1-256 characters"),
+        )
+        .into_response();
+    }
+
     let engine = state.engine.clone();
+    let topic_owned = trimmed.to_string();
 
     let result =
-        tokio::task::spawn_blocking(move || engine.store().remove_topic_subscription(&topic)).await;
+        tokio::task::spawn_blocking(move || engine.store().remove_topic_subscription(&topic_owned))
+            .await;
 
     match result {
         Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -46,6 +46,39 @@ async fn json_body(response: axum::response::Response) -> Value {
     serde_json::from_slice(&body).unwrap()
 }
 
+fn assert_validation_error(
+    json: &Value,
+    expected_code: &str,
+    expected_field: &str,
+    expected_message_fragment: &str,
+) {
+    assert_eq!(json["success"], false);
+    assert_eq!(json["error"]["code"], expected_code);
+    assert_eq!(json["error"]["details"][0]["field"], expected_field);
+    assert!(
+        json["error"]["details"][0]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains(expected_message_fragment),
+        "expected validation message containing {:?}, got {:?}",
+        expected_message_fragment,
+        json["error"]["details"][0]["message"]
+    );
+}
+
+fn assert_validation_error_code_and_field(json: &Value, expected_code: &str, expected_field: &str) {
+    assert_eq!(json["success"], false);
+    assert_eq!(json["error"]["code"], expected_code);
+    assert_eq!(json["error"]["details"][0]["field"], expected_field);
+    assert!(
+        json["error"]["details"][0]["message"]
+            .as_str()
+            .is_some_and(|message| !message.is_empty()),
+        "expected non-empty validation detail message, got {:?}",
+        json["error"]["details"][0]["message"]
+    );
+}
+
 // ============ GROUP TESTS ============
 
 #[tokio::test]
@@ -194,6 +227,40 @@ async fn test_join_and_leave_group() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn test_join_group_invalid_member_id_returns_structured_error() {
+    let (_engine, app) = create_test_app();
+
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/groups")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"group_id": "join-test"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/groups/join-test/join")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"member_id":"not-a-public-id"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert_validation_error(&json, "INVALID_MEMBER_ID", "member_id", "@<base64>.ed25519");
 }
 
 #[tokio::test]
@@ -363,6 +430,27 @@ async fn test_topic_subscription_lifecycle() {
     assert!(!topics.contains(&"rust"));
 }
 
+#[tokio::test]
+async fn test_topic_subscription_invalid_topic_returns_structured_error() {
+    let (_engine, app) = create_test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/topics/%20")
+                .header("content-type", "application/json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert_validation_error(&json, "INVALID_TOPIC", "topic", "1-256 characters");
+}
+
 // ============ IDENTITY TESTS ============
 
 #[tokio::test]
@@ -499,6 +587,29 @@ async fn test_list_schemas() {
     assert!(json["success"].as_bool().unwrap());
 }
 
+#[tokio::test]
+async fn test_register_schema_invalid_payload_returns_structured_error() {
+    let (_engine, app) = create_test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/schemas")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"content_type":"","version":1,"json_schema":"not-an-object"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert_validation_error(&json, "INVALID_CONTENT_TYPE", "content_type", "non-empty");
+}
+
 // ============ RETENTION TESTS ============
 
 #[tokio::test]
@@ -519,6 +630,32 @@ async fn test_list_retention_policies() {
     assert_eq!(response.status(), StatusCode::OK);
     let json = json_body(response).await;
     assert!(json["success"].as_bool().unwrap());
+}
+
+#[tokio::test]
+async fn test_create_retention_policy_invalid_payload_returns_structured_error() {
+    let (_engine, app) = create_test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/retention/policies")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"scope":"global","max_age_secs":0}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = json_body(response).await;
+    assert_validation_error(
+        &json,
+        "INVALID_MAX_AGE_SECS",
+        "max_age_secs",
+        "greater than 0",
+    );
 }
 
 // ============ CSRF PROTECTION TESTS ============
@@ -670,11 +807,13 @@ async fn test_publish_invalid_json_returns_error() {
         .await
         .unwrap();
 
-    // Should return 422 Unprocessable Entity or 400 Bad Request
     assert!(
         response.status() == StatusCode::UNPROCESSABLE_ENTITY
             || response.status() == StatusCode::BAD_REQUEST
     );
+
+    let json = json_body(response).await;
+    assert_validation_error_code_and_field(&json, "INVALID_JSON_BODY", "body");
 }
 
 // ============ EVENTS (SSE) TESTS ============


### PR DESCRIPTION
## Summary
- return structured field-level validation details for JSON body and path validation failures
- validate schema and retention payloads before applying them
- add API coverage for malformed publish, group, topic, schema, and retention requests

Closes #95