### PR TITLE
feat: add private box message encryption

### DIFF
--- a/src/api/routes_events.rs
+++ b/src/api/routes_events.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use tokio::sync::broadcast;
 
 use crate::api::AppState;
+use crate::feed::private_box;
 
 /// Query parameters for event subscription.
 #[derive(Deserialize, Default)]
@@ -43,11 +44,25 @@ pub async fn subscribe(
     Query(params): Query<EventParams>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     let mut rx = state.engine.subscribe();
+    let identity = state.identity.clone();
 
     let stream = async_stream::stream! {
         loop {
             match rx.recv().await {
                 Ok(msg) => {
+                    let msg = if private_box::is_private_box_content(&msg.content) {
+                        match private_box::decrypt_for_identity(&identity, msg.as_ref()) {
+                            Ok(Some(decrypted)) => std::sync::Arc::new(decrypted),
+                            Ok(None) => msg,
+                            Err(error) => {
+                                tracing::warn!(error = %error, hash = %msg.hash, "failed to decrypt private box SSE message");
+                                msg
+                            }
+                        }
+                    } else {
+                        msg
+                    };
+
                     // Apply content_type filter
                     if let Some(ref ct) = params.content_type {
                         let msg_type = msg

--- a/src/api/routes_feed.rs
+++ b/src/api/routes_feed.rs
@@ -14,6 +14,8 @@ use serde::Deserialize;
 use crate::api::response;
 use crate::api::AppState;
 use crate::feed::models::FeedQuery;
+use crate::feed::models::Message;
+use crate::feed::private_box;
 use crate::identity::PublicId;
 
 #[derive(Deserialize, Default)]
@@ -40,6 +42,7 @@ pub async fn get_feed(
     Query(params): Query<FeedParams>,
 ) -> impl IntoResponse {
     let engine = state.engine.clone();
+    let identity = state.identity.clone();
     let include_self = params.include_self.unwrap_or(false);
     let self_id = state.identity.public_id();
 
@@ -59,6 +62,10 @@ pub async fn get_feed(
 
     match result {
         Ok(Ok(msgs)) => {
+            let msgs: Vec<Message> = msgs
+                .into_iter()
+                .map(|msg| decrypt_for_local_identity(&identity, msg))
+                .collect();
             let meta = response::ApiMetadata {
                 total: None,
                 limit: params.limit,
@@ -82,6 +89,7 @@ pub async fn get_feed_by_author(
     Query(params): Query<FeedParams>,
 ) -> impl IntoResponse {
     let engine = state.engine.clone();
+    let identity = state.identity.clone();
 
     let result = tokio::task::spawn_blocking(move || {
         engine.query(&FeedQuery {
@@ -95,7 +103,13 @@ pub async fn get_feed_by_author(
     .await;
 
     match result {
-        Ok(Ok(msgs)) => response::ok(msgs).into_response(),
+        Ok(Ok(msgs)) => {
+            let msgs: Vec<Message> = msgs
+                .into_iter()
+                .map(|msg| decrypt_for_local_identity(&identity, msg))
+                .collect();
+            response::ok(msgs).into_response()
+        }
         Ok(Err(e)) => response::from_error(e),
         Err(_) => response::err::<()>(
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -111,6 +125,7 @@ pub async fn get_insights(
     Query(params): Query<FeedParams>,
 ) -> impl IntoResponse {
     let engine = state.engine.clone();
+    let identity = state.identity.clone();
 
     let result = tokio::task::spawn_blocking(move || {
         engine.query(&FeedQuery {
@@ -123,7 +138,13 @@ pub async fn get_insights(
     .await;
 
     match result {
-        Ok(Ok(msgs)) => response::ok(msgs).into_response(),
+        Ok(Ok(msgs)) => {
+            let msgs: Vec<Message> = msgs
+                .into_iter()
+                .map(|msg| decrypt_for_local_identity(&identity, msg))
+                .collect();
+            response::ok(msgs).into_response()
+        }
         Ok(Err(e)) => response::from_error(e),
         Err(_) => response::err::<()>(
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -139,6 +160,7 @@ pub async fn search_insights(
     Query(params): Query<SearchParams>,
 ) -> impl IntoResponse {
     let engine = state.engine.clone();
+    let identity = state.identity.clone();
     let query_text = params.q.unwrap_or_default();
     let limit = params.limit.unwrap_or(20).min(200);
 
@@ -154,7 +176,13 @@ pub async fn search_insights(
     let result = tokio::task::spawn_blocking(move || engine.search(&query_text, limit)).await;
 
     match result {
-        Ok(Ok(msgs)) => response::ok(msgs).into_response(),
+        Ok(Ok(msgs)) => {
+            let msgs: Vec<Message> = msgs
+                .into_iter()
+                .map(|msg| decrypt_for_local_identity(&identity, msg))
+                .collect();
+            response::ok(msgs).into_response()
+        }
         Ok(Err(e)) => response::from_error(e),
         Err(_) => response::err::<()>(
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -170,11 +198,14 @@ pub async fn get_message_by_hash(
     Path(hash): Path<String>,
 ) -> impl IntoResponse {
     let engine = state.engine.clone();
+    let identity = state.identity.clone();
 
     let result = tokio::task::spawn_blocking(move || engine.get_message(&hash)).await;
 
     match result {
-        Ok(Ok(Some(msg))) => response::ok(msg).into_response(),
+        Ok(Ok(Some(msg))) => {
+            response::ok(decrypt_for_local_identity(&identity, msg)).into_response()
+        }
         Ok(Ok(None)) => response::err::<()>(
             axum::http::StatusCode::NOT_FOUND,
             "NOT_FOUND",
@@ -188,5 +219,20 @@ pub async fn get_message_by_hash(
             "failed to retrieve message",
         )
         .into_response(),
+    }
+}
+
+fn decrypt_for_local_identity(identity: &crate::identity::Identity, message: Message) -> Message {
+    if !private_box::is_private_box_content(&message.content) {
+        return message;
+    }
+
+    match private_box::decrypt_for_identity(identity, &message) {
+        Ok(Some(decrypted)) => decrypted,
+        Ok(None) => message,
+        Err(error) => {
+            tracing::warn!(error = %error, hash = %message.hash, "failed to decrypt private box message");
+            message
+        }
     }
 }

--- a/src/feed/engine.rs
+++ b/src/feed/engine.rs
@@ -8,6 +8,7 @@ use tokio::sync::broadcast;
 
 use crate::error::{EgreError, Result};
 use crate::feed::models::{FeedQuery, Message, UnsignedMessage};
+use crate::feed::private_box;
 use crate::feed::schema::SchemaRegistry;
 use crate::feed::store::FeedStore;
 use crate::identity::{sign_bytes, verify_signature, Identity};
@@ -140,9 +141,20 @@ impl FeedEngine {
         trace_id: Option<String>,
         span_id: Option<String>,
     ) -> Result<Message> {
-        // Determine effective schema_id
-        let effective_schema_id =
-            schema_id.or_else(|| self.schema_registry.infer_schema_id(&content));
+        let mut content = content;
+        let original_schema_id = schema_id
+            .clone()
+            .or_else(|| self.schema_registry.infer_schema_id(&content));
+
+        let (content, effective_schema_id) = if let Some(prepared) =
+            private_box::prepare_for_publish(identity, content.clone(), original_schema_id.clone())?
+        {
+            self.schema_registry
+                .validate(&prepared.plaintext_content, original_schema_id.as_deref())?;
+            (prepared.encrypted_content, prepared.schema_id)
+        } else {
+            (std::mem::take(&mut content), original_schema_id)
+        };
 
         // Validate content against schema
         self.schema_registry

--- a/src/feed/mod.rs
+++ b/src/feed/mod.rs
@@ -1,5 +1,6 @@
 pub mod content_types;
 pub mod engine;
 pub mod models;
+pub mod private_box;
 pub mod schema;
 pub mod store;

--- a/src/feed/private_box.rs
+++ b/src/feed/private_box.rs
@@ -1,0 +1,209 @@
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+use crate::crypto::private_box::{box_message, unbox_message};
+use crate::error::{EgreError, Result};
+use crate::feed::models::Message;
+use crate::identity::{Identity, PublicId};
+
+pub const PRIVATE_BOX_SCHEMA_ID: &str = "private_box/v1";
+const PRIVATE_BOX_TYPE: &str = "private_box";
+const ENCRYPT_FOR_FIELD: &str = "encrypt_for";
+
+#[derive(Debug, Clone)]
+pub struct PreparedPrivateBox {
+    pub plaintext_content: serde_json::Value,
+    pub encrypted_content: serde_json::Value,
+    pub schema_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PrivateBoxEnvelope {
+    #[serde(rename = "type")]
+    msg_type: String,
+    sender: PublicId,
+    #[serde(rename = "box")]
+    boxed_payload: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    inner_schema_id: Option<String>,
+}
+
+pub fn prepare_for_publish(
+    sender: &Identity,
+    mut content: serde_json::Value,
+    original_schema_id: Option<String>,
+) -> Result<Option<PreparedPrivateBox>> {
+    let Some(recipients) = extract_recipients(&mut content)? else {
+        return Ok(None);
+    };
+
+    let plaintext = serde_json::to_vec(&content)?;
+    let mut recipient_keys = Vec::with_capacity(recipients.len() + 1);
+    for recipient in recipients {
+        recipient_keys.push(recipient.to_x25519_public_key()?);
+    }
+    recipient_keys.push(sender.to_x25519_public_key());
+
+    let ciphertext = box_message(sender, &recipient_keys, &plaintext)?;
+    let envelope = PrivateBoxEnvelope {
+        msg_type: PRIVATE_BOX_TYPE.to_string(),
+        sender: sender.public_id(),
+        boxed_payload: B64.encode(ciphertext),
+        inner_schema_id: original_schema_id,
+    };
+
+    Ok(Some(PreparedPrivateBox {
+        plaintext_content: content,
+        encrypted_content: serde_json::to_value(envelope)?,
+        schema_id: Some(PRIVATE_BOX_SCHEMA_ID.to_string()),
+    }))
+}
+
+pub fn decrypt_for_identity(identity: &Identity, message: &Message) -> Result<Option<Message>> {
+    let envelope = parse_envelope(&message.content)?;
+    let ciphertext = B64
+        .decode(envelope.boxed_payload)
+        .map_err(|error| EgreError::Crypto {
+            reason: format!("invalid private box payload: {error}"),
+        })?;
+    let sender_x25519 = envelope.sender.to_x25519_public_key()?;
+    let Some(plaintext) = unbox_message(identity, &sender_x25519, &ciphertext)? else {
+        return Ok(None);
+    };
+
+    let content = serde_json::from_slice(&plaintext)?;
+    let mut decrypted = message.clone();
+    decrypted.content = content;
+    decrypted.schema_id = envelope.inner_schema_id;
+    Ok(Some(decrypted))
+}
+
+pub fn is_private_box_content(content: &serde_json::Value) -> bool {
+    content
+        .get("type")
+        .and_then(|value| value.as_str())
+        .is_some_and(|value| value == PRIVATE_BOX_TYPE)
+}
+
+fn extract_recipients(content: &mut serde_json::Value) -> Result<Option<Vec<PublicId>>> {
+    let Some(object) = content.as_object_mut() else {
+        return Ok(None);
+    };
+
+    let Some(raw_recipients) = object.remove(ENCRYPT_FOR_FIELD) else {
+        return Ok(None);
+    };
+
+    let recipients = raw_recipients
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str())
+        .map(|value| PublicId(value.to_string()))
+        .collect::<Vec<_>>();
+
+    Ok(Some(recipients))
+}
+
+fn parse_envelope(content: &serde_json::Value) -> Result<PrivateBoxEnvelope> {
+    Ok(serde_json::from_value(content.clone())?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepare_for_publish_strips_encrypt_for_and_wraps_content() {
+        let sender = Identity::generate();
+        let recipient = Identity::generate();
+        let plaintext = serde_json::json!({
+            "type": "message",
+            "text": "secret",
+            "encrypt_for": [recipient.public_id().0],
+        });
+
+        let prepared = prepare_for_publish(&sender, plaintext, Some("message/v1".to_string()))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(prepared.plaintext_content["type"], "message");
+        assert!(prepared.plaintext_content.get("encrypt_for").is_none());
+        assert_eq!(prepared.encrypted_content["type"], PRIVATE_BOX_TYPE);
+        assert_eq!(prepared.schema_id.as_deref(), Some(PRIVATE_BOX_SCHEMA_ID));
+    }
+
+    #[test]
+    fn recipient_can_decrypt_private_box_message() {
+        let sender = Identity::generate();
+        let recipient = Identity::generate();
+        let prepared = prepare_for_publish(
+            &sender,
+            serde_json::json!({
+                "type": "message",
+                "text": "secret",
+                "encrypt_for": [recipient.public_id().0],
+            }),
+            Some("message/v1".to_string()),
+        )
+        .unwrap()
+        .unwrap();
+
+        let message = Message {
+            author: sender.public_id(),
+            sequence: 1,
+            previous: None,
+            timestamp: chrono::Utc::now(),
+            content: prepared.encrypted_content,
+            schema_id: prepared.schema_id,
+            relates: None,
+            tags: vec![],
+            trace_id: None,
+            span_id: None,
+            expires_at: None,
+            hash: "hash".to_string(),
+            signature: "sig".to_string(),
+        };
+
+        let decrypted = decrypt_for_identity(&recipient, &message).unwrap().unwrap();
+        assert_eq!(decrypted.content["text"], "secret");
+        assert_eq!(decrypted.schema_id.as_deref(), Some("message/v1"));
+    }
+
+    #[test]
+    fn outsider_cannot_decrypt_private_box_message() {
+        let sender = Identity::generate();
+        let recipient = Identity::generate();
+        let outsider = Identity::generate();
+        let prepared = prepare_for_publish(
+            &sender,
+            serde_json::json!({
+                "type": "message",
+                "text": "secret",
+                "encrypt_for": [recipient.public_id().0],
+            }),
+            Some("message/v1".to_string()),
+        )
+        .unwrap()
+        .unwrap();
+
+        let message = Message {
+            author: sender.public_id(),
+            sequence: 1,
+            previous: None,
+            timestamp: chrono::Utc::now(),
+            content: prepared.encrypted_content,
+            schema_id: prepared.schema_id,
+            relates: None,
+            tags: vec![],
+            trace_id: None,
+            span_id: None,
+            expires_at: None,
+            hash: "hash".to_string(),
+            signature: "sig".to_string(),
+        };
+
+        assert!(decrypt_for_identity(&outsider, &message).unwrap().is_none());
+    }
+}

--- a/src/feed/schema.rs
+++ b/src/feed/schema.rs
@@ -159,6 +159,28 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
 }"#,
     ),
     (
+        "private_box.v1.json",
+        r#"{
+  "content_type": "private_box",
+  "version": 1,
+  "description": "Encrypted multi-recipient message wrapper",
+  "codec": "json",
+  "compatibility": "backward",
+  "json_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["type", "sender", "box"],
+    "properties": {
+      "type": { "const": "private_box" },
+      "sender": { "type": "string", "pattern": "^@.+\\.ed25519$" },
+      "box": { "type": "string", "minLength": 1 },
+      "inner_schema_id": { "type": ["string", "null"] }
+    },
+    "additionalProperties": false
+  }
+}"#,
+    ),
+    (
         "profile.v1.json",
         r#"{
   "content_type": "profile",
@@ -1031,13 +1053,14 @@ mod tests {
         let (registry, temp_dir) = registry_with_defaults(false);
         let all = registry.list_all();
 
-        // Should have all 7 default schemas
-        assert_eq!(all.len(), 7);
+        // Should have all default schemas, including private_box.
+        assert_eq!(all.len(), 8);
 
         let schema_ids: Vec<&str> = all.iter().map(|s| s.schema_id.as_str()).collect();
         assert!(schema_ids.contains(&"insight/v1"));
         assert!(schema_ids.contains(&"profile/v1"));
         assert!(schema_ids.contains(&"message/v1"));
+        assert!(schema_ids.contains(&"private_box/v1"));
         let _ = std::fs::remove_dir_all(&temp_dir);
     }
 

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -22,22 +22,28 @@ use tower::ServiceExt;
 ///
 /// Uses in-memory SQLite and generates a fresh identity for each test.
 fn create_test_app() -> (Arc<FeedEngine>, axum::Router) {
+    let (identity, engine) = create_test_engine();
+    let app = create_test_app_with_identity(identity, engine.clone());
+    (engine, app)
+}
+
+fn create_test_engine() -> (Identity, Arc<FeedEngine>) {
     let identity = Identity::generate();
     let store = FeedStore::open_memory().unwrap();
     let engine = Arc::new(FeedEngine::new(store));
+    (identity, engine)
+}
 
+fn create_test_app_with_identity(identity: Identity, engine: Arc<FeedEngine>) -> axum::Router {
     let state = AppState {
         identity,
-        engine: engine.clone(),
+        engine,
         config: Arc::new(Config::default()),
         started_at: Instant::now(),
         mcp_registry: mcp_registry::create_registry(),
     };
 
-    // Use production router without MCP to avoid endpoint conflicts in tests
-    let app = router_with_mcp(state, false);
-
-    (engine, app)
+    router_with_mcp(state, false)
 }
 
 /// Helper to parse JSON response body.
@@ -814,6 +820,107 @@ async fn test_publish_invalid_json_returns_error() {
 
     let json = json_body(response).await;
     assert_validation_error_code_and_field(&json, "INVALID_JSON_BODY", "body");
+}
+
+#[tokio::test]
+async fn test_private_box_publish_stores_ciphertext_but_decrypts_for_sender() {
+    let (sender, engine) = create_test_engine();
+    let app = create_test_app_with_identity(sender.clone(), engine.clone());
+    let recipient = Identity::generate();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/publish")
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{
+                        "content": {{
+                            "type": "message",
+                            "text": "top secret",
+                            "encrypt_for": ["{}"]
+                        }}
+                    }}"#,
+                    recipient.public_id().0
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let stored = engine.query(&Default::default()).unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].content["type"], "private_box");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/feed?include_self=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_body(response).await;
+    let data = json["data"].as_array().unwrap();
+    assert_eq!(data[0]["content"]["type"], "message");
+    assert_eq!(data[0]["content"]["text"], "top secret");
+}
+
+#[tokio::test]
+async fn test_private_box_remains_ciphertext_for_non_recipient() {
+    let (sender, engine) = create_test_engine();
+    let sender_app = create_test_app_with_identity(sender, engine.clone());
+    let outsider_app = create_test_app_with_identity(Identity::generate(), engine.clone());
+    let recipient = Identity::generate();
+
+    let response = sender_app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/publish")
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{
+                        "content": {{
+                            "type": "message",
+                            "text": "top secret",
+                            "encrypt_for": ["{}"]
+                        }}
+                    }}"#,
+                    recipient.public_id().0
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = outsider_app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/feed?include_self=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_body(response).await;
+    let data = json["data"].as_array().unwrap();
+    assert_eq!(data[0]["content"]["type"], "private_box");
+    assert!(data[0]["content"]["box"].is_string());
 }
 
 // ============ EVENTS (SSE) TESTS ============


### PR DESCRIPTION
Closes #97

## Summary
- encrypt messages with content.encrypt_for into private_box envelopes before storage and replication
- decrypt private_box messages for authorized recipients on feed reads and SSE delivery while leaving ciphertext visible to others
- add schema and integration coverage for encrypted publish/query behavior

## Testing
- cargo test --manifest-path /home/pknull/Code/Thallus/egregore/Cargo.toml