### PR TITLE
docs: sync egregore auth and status docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ Generate a documented config file:
 
 This creates `./data/config.yaml` with all options and defaults. Edit this file for persistent configuration. CLI flags override config file values when both are specified.
 
-The config file supports options not available via CLI (flow control, retention settings) and persistent toggles like `schema_strict`, `api_enabled`, `api_auth_enabled`, `mcp_enabled`, and `node_status_enabled`. See the generated template for full documentation.
+The config file supports options not available via CLI (flow control, retention settings) and persistent toggles like `schema_strict`, `api_enabled`, `api_auth_enabled`, `mcp_enabled`, and `node_status_enabled`. `node_status_enabled` is off by default; turn it on only if you want periodic `node_status` messages published to the feed. See the generated template for full documentation.
 
-Compatibility note: REST API auth is off by default. Set `api_auth_enabled: true` and `api_auth_token: "..."` to require `Authorization: Bearer ...` on mutating `/v1/...` routes without breaking existing local read-only integrations.
+Compatibility note: REST API auth is off by default. Set `api_auth_enabled: true` and `api_auth_token: "..."` to require `Authorization: Bearer ...` on mutating `/v1/...` routes and mutating MCP tools without breaking existing local read-only integrations.
 
 ### Interfaces
 
@@ -244,7 +244,7 @@ Compatibility note: REST API auth is off by default. Set `api_auth_enabled: true
 
 Response envelope: `{ success, data, error, metadata }`. Pagination uses `limit`/`offset`.
 
-When `api_auth_enabled: true`, mutating REST endpoints under `/v1/...` require `Authorization: Bearer <token>`. Missing or invalid auth returns `401` with the standard error envelope. Read-only routes such as `GET /v1/status`, `GET /v1/feed`, and `GET /v1/events` remain accessible without auth. `/mcp` is not covered by this toggle in this release.
+When `api_auth_enabled: true`, mutating REST endpoints under `/v1/...` require `Authorization: Bearer <token>`. Missing or invalid auth returns `401` with the standard error envelope. Read-only routes such as `GET /v1/status`, `GET /v1/feed`, and `GET /v1/events` remain accessible without auth. MCP follows the same split: read-only tools stay public, while mutating tools (`egregore_publish`, `egregore_add_peer`, `egregore_remove_peer`, `egregore_follow`, `egregore_unfollow`) require the same Bearer token and return an MCP tool error if auth is missing or invalid.
 
 ### MCP Integration
 

--- a/docs/features/integration-api-and-mcp.md
+++ b/docs/features/integration-api-and-mcp.md
@@ -64,7 +64,10 @@ cargo run -- --data-dir ./data --no-api
 |---|---|
 | `port` | API port (localhost bind) |
 | `api_enabled` | Enable HTTP API |
+| `api_auth_enabled` | Require a Bearer token for mutating REST routes and mutating MCP tools |
+| `api_auth_token` | Shared Bearer token checked when `api_auth_enabled` is true |
 | `mcp_enabled` | Enable MCP route |
+| `node_status_enabled` | Publish periodic `node_status` feed messages; disabled by default |
 
 ## API Surface
 
@@ -77,8 +80,25 @@ cargo run -- --data-dir ./data --no-api
 | `GET /v1/events` | SSE event stream |
 | `POST /mcp` | MCP endpoint (if enabled) |
 
+## Auth Behavior
+
+When `api_auth_enabled: true`, mutating REST endpoints under `/v1/...` require
+`Authorization: Bearer <token>`. Read-only routes stay available on localhost
+without auth.
+
+MCP follows the same split: read-only tools remain public, while mutating tools
+such as `egregore_publish`, `egregore_add_peer`, `egregore_remove_peer`,
+`egregore_follow`, and `egregore_unfollow` require the same Bearer token.
+
+## Status Publishing
+
+`node_status_enabled` controls whether the node periodically publishes signed
+`node_status` messages onto the feed. It is disabled by default to avoid
+background feed noise unless an operator explicitly wants those health
+announcements.
+
 ## Documentation Gaps
 
 1. HTTP API auth/TLS is not configurable in-process.
-2. No per-endpoint authorization model exists; trust boundary is localhost and system edge controls.
+2. Authorization is coarse-grained: mutating REST routes and mutating MCP tools share one Bearer token.
 3. No generated “minimal MCP client setup” snippets are published for each major client runtime.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,7 +3,8 @@
 //! All endpoints bind to 127.0.0.1 (binding happens in main.rs). Only local
 //! processes can access the API. Mutating REST endpoints can optionally require
 //! a Bearer token, while read-only routes remain loopback-only without auth.
-//! MCP auth is handled separately.
+//! MCP follows the same split: read-only tools remain public, while mutating
+//! tools enforce the configured Bearer token inside the MCP handlers.
 //!
 //! ## CSRF Protection
 //!
@@ -106,7 +107,7 @@ async fn require_json_content_type(req: Request<Body>, next: Next) -> Response {
 /// Optional Bearer token auth for mutating REST endpoints.
 ///
 /// Only applies to mutating `/v1/...` routes. Read-only routes remain accessible
-/// without auth, and `/mcp` is intentionally excluded until issue #89.
+/// without auth. MCP mutating-tool auth is enforced in the MCP dispatch layer.
 async fn require_api_auth(
     State(config): State<Arc<Config>>,
     req: Request<Body>,
@@ -463,7 +464,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auth_does_not_gate_mcp_requests_in_this_branch() {
+    async fn api_auth_middleware_does_not_gate_mcp_route() {
         let state = test_state_with_config(Config {
             api_auth_enabled: true,
             api_auth_token: Some("secret-token".to_string()),


### PR DESCRIPTION
## Summary
- update README auth notes to reflect current mutating MCP tool auth behavior
- clarify that node_status publishing is opt-in and document the toggle consistently
- sync internal API module commentary with the current auth split

## Validation
- cargo test --manifest-path /home/pknull/Code/Thallus/egregore-docs/Cargo.toml