### PR TITLE
fix: add feed trace filtering

### DIFF
--- a/src/api/routes_feed.rs
+++ b/src/api/routes_feed.rs
@@ -23,6 +23,8 @@ pub struct FeedParams {
     pub limit: Option<u32>,
     pub offset: Option<u32>,
     pub content_type: Option<String>,
+    /// Filter by distributed trace identifier.
+    pub trace_id: Option<String>,
     /// Filter by tag.
     pub tag: Option<String>,
     /// Filter by related message hash (find replies/responses).
@@ -51,6 +53,7 @@ pub async fn get_feed(
             author: None,
             exclude_author: if include_self { None } else { Some(self_id) },
             content_type: params.content_type,
+            trace_id: params.trace_id,
             tag: params.tag,
             relates: params.relates,
             limit: params.limit,
@@ -95,6 +98,7 @@ pub async fn get_feed_by_author(
         engine.query(&FeedQuery {
             author: Some(PublicId(author)),
             content_type: params.content_type,
+            trace_id: params.trace_id,
             limit: params.limit,
             offset: params.offset,
             ..Default::default()
@@ -130,6 +134,7 @@ pub async fn get_insights(
     let result = tokio::task::spawn_blocking(move || {
         engine.query(&FeedQuery {
             content_type: Some("insight".to_string()),
+            trace_id: params.trace_id,
             limit: params.limit,
             offset: params.offset,
             ..Default::default()

--- a/src/feed/models.rs
+++ b/src/feed/models.rs
@@ -104,6 +104,8 @@ pub struct FeedQuery {
     /// Exclude messages from this author (used for "others only" queries).
     pub exclude_author: Option<PublicId>,
     pub content_type: Option<String>,
+    /// Filter by distributed trace identifier.
+    pub trace_id: Option<String>,
     /// Filter by tag (messages must have this tag).
     pub tag: Option<String>,
     /// Filter by relates hash (messages that reference this hash).

--- a/src/feed/store/messages.rs
+++ b/src/feed/store/messages.rs
@@ -253,6 +253,14 @@ impl FeedStore {
             param_values.push(Box::new(ct.clone()));
         }
 
+        if let Some(ref trace_id) = query.trace_id {
+            sql.push_str(&format!(
+                " AND json_extract(m.raw_json, '$.trace_id') = ?{}",
+                param_values.len() + 1
+            ));
+            param_values.push(Box::new(trace_id.clone()));
+        }
+
         if let Some(ref relates) = query.relates {
             sql.push_str(&format!(" AND m.relates = ?{}", param_values.len() + 1));
             param_values.push(Box::new(relates.clone()));
@@ -626,6 +634,28 @@ mod tests {
         };
         let results = store.query_messages(&query).unwrap();
         assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn query_by_trace_id() {
+        let store = FeedStore::open_memory().unwrap();
+
+        let mut trace_a = make_test_message("@alice.ed25519", 1, None);
+        trace_a.trace_id = Some("trace-a".to_string());
+        store.insert_message(&trace_a, true).unwrap();
+
+        let mut trace_b = make_test_message("@bob.ed25519", 1, None);
+        trace_b.trace_id = Some("trace-b".to_string());
+        store.insert_message(&trace_b, true).unwrap();
+
+        let query = FeedQuery {
+            trace_id: Some("trace-a".to_string()),
+            ..Default::default()
+        };
+        let results = store.query_messages(&query).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].trace_id.as_deref(), Some("trace-a"));
     }
 
     #[test]

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -797,6 +797,55 @@ async fn test_publish_with_tags_and_relates() {
 }
 
 #[tokio::test]
+async fn test_get_feed_filters_by_trace_id() {
+    let (_engine, app) = create_test_app();
+
+    for trace_id in ["trace-keep", "trace-skip"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/publish")
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{
+                            "content": {{
+                                "type": "message",
+                                "text": "message for {trace_id}"
+                            }},
+                            "trace_id": "{trace_id}"
+                        }}"#
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/feed?include_self=true&trace_id=trace-keep")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = json_body(response).await;
+    let data = json["data"].as_array().unwrap();
+
+    assert_eq!(data.len(), 1);
+    assert_eq!(data[0]["trace_id"], "trace-keep");
+    assert_eq!(data[0]["content"]["text"], "message for trace-keep");
+}
+
+#[tokio::test]
 async fn test_publish_invalid_json_returns_error() {
     let (_engine, app) = create_test_app();
 


### PR DESCRIPTION
## Summary
- add `trace_id` filtering to feed query params and the backend feed query model
- apply the filter in SQLite feed lookups so trace views can request exact spans instead of sampling recent traffic
- cover the new store-level and HTTP-level filter behavior with tests

## Testing
- cargo fmt
- cargo test query_by_trace_id
- cargo test test_get_feed_filters_by_trace_id
- cargo test