### PR TITLE
Phase 2 Wave 5: Observability (Steps 24-27)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -33,6 +33,7 @@ pub mod routes_publish;
 pub mod routes_retention;
 pub mod routes_schema;
 pub mod routes_topics;
+pub mod routes_transport;
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -219,7 +220,18 @@ pub fn router_with_mcp(state: AppState, mcp_enabled: bool) -> Router {
             post(routes_blobs::upload_blob).layer(DefaultBodyLimit::max(100 * 1024 * 1024)), // 100 MB for blob uploads
         )
         .route("/v1/blobs/:hash", get(routes_blobs::download_blob))
-        .route("/v1/blobs/:hash/info", get(routes_blobs::blob_info));
+        .route("/v1/blobs/:hash/info", get(routes_blobs::blob_info))
+        // Phase 2 Wave 5 Step 26 — scry bridge panel data feeds
+        // (amendment §C.14). Both are read-only observability
+        // endpoints — no auth gate, CSRF-exempt since they're GET-only.
+        .route(
+            "/v1/transport/pending",
+            get(routes_transport::get_transport_pending),
+        )
+        .route(
+            "/v1/transport/bus/authors",
+            get(routes_transport::get_bus_authors),
+        );
 
     // Consumer groups API (advanced feature; off by default).
     let router = if state.config.consumer_groups_enabled {

--- a/src/api/routes_mesh.rs
+++ b/src/api/routes_mesh.rs
@@ -207,6 +207,7 @@ mod tests {
                 follow_count: 0,
                 uptime_secs: 0,
                 health: None,
+                transport: None,
             },
             peers: vec![],
             health: None,
@@ -232,6 +233,7 @@ mod tests {
                 follow_count: 0,
                 uptime_secs: 0,
                 health: None,
+                transport: None,
             },
             peers: vec![],
             health: Some(HealthIndicators {

--- a/src/api/routes_peers.rs
+++ b/src/api/routes_peers.rs
@@ -395,9 +395,7 @@ mod tests {
     use crate::feed::store::FeedStore;
     use crate::identity::Identity;
     use crate::transport::health::TransportHealth;
-    use crate::transport::{
-        filter::TopicFilter, subscription::SubscriptionHandle, Transport,
-    };
+    use crate::transport::{filter::TopicFilter, subscription::SubscriptionHandle, Transport};
     use async_trait::async_trait;
     use futures::stream::BoxStream;
     use std::sync::Arc;
@@ -413,12 +411,17 @@ mod tests {
     #[async_trait]
     impl Transport for StatusInlineMockTransport {
         async fn publish(&self, _msg: &crate::feed::models::Message) -> crate::error::Result<()> {
-            unimplemented!("StatusInlineMockTransport::publish — not exercised by build_status tests")
+            unimplemented!(
+                "StatusInlineMockTransport::publish — not exercised by build_status tests"
+            )
         }
         async fn subscribe(
             &self,
             _filter: TopicFilter,
-        ) -> crate::error::Result<(SubscriptionHandle, BoxStream<'static, crate::feed::models::Message>)> {
+        ) -> crate::error::Result<(
+            SubscriptionHandle,
+            BoxStream<'static, crate::feed::models::Message>,
+        )> {
             unimplemented!(
                 "StatusInlineMockTransport::subscribe — not exercised by build_status tests"
             )

--- a/src/api/routes_peers.rs
+++ b/src/api/routes_peers.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::response;
 use crate::api::AppState;
+use crate::transport::health::TransportHealth;
 
 #[derive(Serialize)]
 pub struct PeerInfo {
@@ -65,6 +66,16 @@ pub struct StatusInfo {
     /// Health indicators for subsystems. Null or absent means healthy (backward compat).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health: Option<HealthIndicators>,
+
+    /// Phase 2 Wave 5 Step 24: transport health from
+    /// `engine.transport_health()`. Present when `transport_count() >= 1`.
+    /// Composite deployments carry `TransportHealth.children` with per-child
+    /// `BridgeQueuesHealth` (RFC 0002 §8.4). Pre-Phase-2 deployments (no
+    /// transports attached; test harnesses) omit the field entirely — the
+    /// `#[serde(default, skip_serializing_if = "Option::is_none")]` pair
+    /// preserves byte-for-byte compatibility with the pre-Phase-2 shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<TransportHealth>,
 }
 
 /// Aggregate peers from all sources (CLI, address table, known_peers) with deduplication.
@@ -269,6 +280,12 @@ pub async fn build_status(state: &AppState) -> StatusInfo {
         })
     };
 
+    // Phase 2 Wave 5 Step 24: surface transport health when at least one
+    // transport is attached. `transport_health()` returns None for
+    // test harnesses that don't attach a transport; the optional field
+    // is omitted from the JSON in that case (see serde attribute).
+    let transport = state.engine.transport_health();
+
     StatusInfo {
         version: env!("CARGO_PKG_VERSION").to_string(),
         identity: state.identity.public_id().0,
@@ -280,6 +297,7 @@ pub async fn build_status(state: &AppState) -> StatusInfo {
         follow_count,
         uptime_secs: uptime,
         health,
+        transport,
     }
 }
 
@@ -313,6 +331,7 @@ mod tests {
             follow_count: 0,
             uptime_secs: 0,
             health: None,
+            transport: None,
         };
         let json = serde_json::to_value(&status).unwrap();
         assert!(
@@ -339,6 +358,7 @@ mod tests {
                     error: "db locked".to_string(),
                 },
             }),
+            transport: None,
         };
         let json = serde_json::to_value(&status).unwrap();
         let health = json
@@ -358,5 +378,135 @@ mod tests {
         })
         .unwrap();
         assert_eq!(degraded["degraded"]["error"], "test error");
+    }
+
+    // ------------------------------------------------------------------
+    // Step 24 — /v1/status exposes `transport: Option<TransportHealth>`.
+    // The field is `None` when no transports are attached (the test-harness
+    // case); `Some(..)` when `engine.transport_count() >= 1`. This mirrors
+    // the `engine.transport_health()` contract exercised in
+    // `src/feed/engine.rs` Step 5 tests.
+    // ------------------------------------------------------------------
+
+    use crate::api::mcp_registry;
+    use crate::blob::BlobStore;
+    use crate::config::Config;
+    use crate::feed::engine::FeedEngine;
+    use crate::feed::store::FeedStore;
+    use crate::identity::Identity;
+    use crate::transport::health::TransportHealth;
+    use crate::transport::{
+        filter::TopicFilter, subscription::SubscriptionHandle, Transport,
+    };
+    use async_trait::async_trait;
+    use futures::stream::BoxStream;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    /// Minimal inline mock transport — canned `health()` response; other
+    /// trait methods unreachable here because `build_status` only consumes
+    /// `engine.transport_health()`.
+    struct StatusInlineMockTransport {
+        health: TransportHealth,
+    }
+
+    #[async_trait]
+    impl Transport for StatusInlineMockTransport {
+        async fn publish(&self, _msg: &crate::feed::models::Message) -> crate::error::Result<()> {
+            unimplemented!("StatusInlineMockTransport::publish — not exercised by build_status tests")
+        }
+        async fn subscribe(
+            &self,
+            _filter: TopicFilter,
+        ) -> crate::error::Result<(SubscriptionHandle, BoxStream<'static, crate::feed::models::Message>)> {
+            unimplemented!(
+                "StatusInlineMockTransport::subscribe — not exercised by build_status tests"
+            )
+        }
+        async fn request_from(
+            &self,
+            _author: crate::identity::PublicId,
+            _after_seq: u64,
+        ) -> crate::error::Result<BoxStream<'static, crate::feed::models::Message>> {
+            unimplemented!(
+                "StatusInlineMockTransport::request_from — not exercised by build_status tests"
+            )
+        }
+        async fn start(&self) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn shutdown(&self, _deadline: Duration) -> crate::error::Result<()> {
+            Ok(())
+        }
+        fn health(&self) -> TransportHealth {
+            self.health.clone()
+        }
+    }
+
+    fn test_app_state_with_engine(engine: Arc<FeedEngine>) -> AppState {
+        let tmp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(tmp.path());
+        AppState {
+            identity: Identity::generate(),
+            engine,
+            config: Arc::new(Config::default()),
+            started_at: Instant::now(),
+            mcp_registry: mcp_registry::create_registry(),
+            blob_store,
+        }
+    }
+
+    #[tokio::test]
+    async fn build_status_includes_transport_when_attached() {
+        let store = FeedStore::open_memory().unwrap();
+        let engine = Arc::new(FeedEngine::new(store));
+
+        // Attach one mock transport reporting connected=true. Single-transport
+        // path: `transport_health()` returns that child's health verbatim.
+        engine.attach_transport(Arc::new(StatusInlineMockTransport {
+            health: TransportHealth {
+                connected: true,
+                backend: "mock-gossip",
+                last_successful_publish: None,
+                last_peer_contact: None,
+                unreplicated_count: 0,
+                inflight_publishes: 0,
+                last_error: None,
+                children: vec![],
+                bridge_queues: None,
+            },
+        }));
+
+        let state = test_app_state_with_engine(engine);
+        let status = build_status(&state).await;
+
+        let transport = status
+            .transport
+            .expect("transport attached => /v1/status.transport is Some");
+        assert_eq!(transport.backend, "mock-gossip");
+        assert!(transport.connected);
+    }
+
+    #[tokio::test]
+    async fn build_status_omits_transport_when_no_transports() {
+        let store = FeedStore::open_memory().unwrap();
+        let engine = Arc::new(FeedEngine::new(store));
+        // Do NOT attach any transport — test harness case.
+
+        let state = test_app_state_with_engine(engine);
+        let status = build_status(&state).await;
+
+        assert!(
+            status.transport.is_none(),
+            "no transports attached => transport field is None (preserves Phase 1 shape)"
+        );
+
+        // Confirm the field is omitted from JSON output (byte-for-byte
+        // compatibility with pre-Phase-2 consumers).
+        let json = serde_json::to_value(&status).unwrap();
+        assert!(
+            json.get("transport").is_none(),
+            "transport field must be omitted from JSON when None; got: {json}"
+        );
     }
 }

--- a/src/api/routes_transport.rs
+++ b/src/api/routes_transport.rs
@@ -1,0 +1,165 @@
+//! Phase 2 Wave 5 Step 26 (amendment §C.14) — transport-observability
+//! endpoints consumed by scry's bridge panel.
+//!
+//! Two endpoints:
+//!
+//! - `GET /v1/transport/pending?transport_id=bus` — count + up to 100
+//!   pending-forwarding rows for the named transport. Feeds scry's
+//!   per-stream lag widget.
+//! - `GET /v1/transport/bus/authors` — per-author summary of
+//!   `bus_author_seq_index`, one row per author with
+//!   `{author, last_indexed_at, author_seq, stream_seq}`. Feeds scry's
+//!   last-ack-per-author widget.
+//!
+//! Both wrap SQLite access in `spawn_blocking` per the async-SQLite
+//! convention documented in CLAUDE.md.
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::api::response;
+use crate::api::AppState;
+
+// ----------------------------------------------------------------------
+// GET /v1/transport/pending
+// ----------------------------------------------------------------------
+
+/// Query string: `?transport_id=bus`.
+#[derive(Debug, Deserialize)]
+pub struct PendingQuery {
+    pub transport_id: String,
+}
+
+/// One row of pending-forwarding state, suitable for operator display.
+/// `last_error` has already been scrubbed at the CRUD layer (auditor A2).
+#[derive(Debug, Serialize)]
+pub struct PendingRowDto {
+    pub message_hash: String,
+    pub author: String,
+    pub sequence: u64,
+    pub enqueued_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_attempt_at: Option<DateTime<Utc>>,
+    pub attempt_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+/// Response envelope wrapped by `response::ok(..)`.
+#[derive(Debug, Serialize)]
+pub struct PendingSummary {
+    pub transport_id: String,
+    pub count: u64,
+    /// Capped at 100 rows for operator display; use MCP/CLI for deep
+    /// inspection.
+    pub rows: Vec<PendingRowDto>,
+}
+
+/// UI row-cap to keep the response bounded.
+const PENDING_LIST_LIMIT: u32 = 100;
+
+pub async fn get_transport_pending(
+    State(state): State<AppState>,
+    Query(params): Query<PendingQuery>,
+) -> impl IntoResponse {
+    let engine = state.engine.clone();
+    let transport_id = params.transport_id;
+
+    let tid = transport_id.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let store = engine.store();
+        let count = store.pending_forwarding_count(&tid)?;
+        let rows = store.pending_forwarding_list(&tid, PENDING_LIST_LIMIT)?;
+        crate::error::Result::Ok((count, rows))
+    })
+    .await;
+
+    match result {
+        Ok(Ok((count, rows))) => {
+            let dtos: Vec<PendingRowDto> = rows
+                .into_iter()
+                .map(|r| PendingRowDto {
+                    message_hash: r.message_hash,
+                    author: r.author,
+                    sequence: r.sequence,
+                    enqueued_at: r.enqueued_at,
+                    last_attempt_at: r.last_attempt_at,
+                    attempt_count: r.attempt_count,
+                    last_error: r.last_error,
+                })
+                .collect();
+            response::ok(PendingSummary {
+                transport_id,
+                count,
+                rows: dtos,
+            })
+            .into_response()
+        }
+        Ok(Err(e)) => response::from_error(e),
+        Err(join_err) => {
+            tracing::error!(error = %join_err, "transport/pending task failed");
+            response::err::<PendingSummary>(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                "failed to read pending-forwarding state",
+            )
+            .into_response()
+        }
+    }
+}
+
+// ----------------------------------------------------------------------
+// GET /v1/transport/bus/authors
+// ----------------------------------------------------------------------
+
+/// One row per author from `bus_author_seq_index`, carrying the
+/// author's highest indexed `(author_seq, stream_seq)` pair + the
+/// timestamp of the last index write.
+#[derive(Debug, Serialize)]
+pub struct BusAuthorRowDto {
+    pub author: String,
+    pub last_indexed_at: DateTime<Utc>,
+    pub author_seq: u64,
+    pub stream_seq: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BusAuthorsSummary {
+    pub rows: Vec<BusAuthorRowDto>,
+}
+
+pub async fn get_bus_authors(State(state): State<AppState>) -> impl IntoResponse {
+    let engine = state.engine.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        engine.store().bus_author_seq_index_author_summary()
+    })
+    .await;
+
+    match result {
+        Ok(Ok(rows)) => {
+            let dtos = rows
+                .into_iter()
+                .map(|r| BusAuthorRowDto {
+                    author: r.author,
+                    last_indexed_at: r.last_indexed_at,
+                    author_seq: r.author_seq,
+                    stream_seq: r.stream_seq,
+                })
+                .collect();
+            response::ok(BusAuthorsSummary { rows: dtos }).into_response()
+        }
+        Ok(Err(e)) => response::from_error(e),
+        Err(join_err) => {
+            tracing::error!(error = %join_err, "transport/bus/authors task failed");
+            response::err::<BusAuthorsSummary>(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                "failed to read bus_author_seq_index",
+            )
+            .into_response()
+        }
+    }
+}

--- a/src/api/routes_transport.rs
+++ b/src/api/routes_transport.rs
@@ -133,10 +133,9 @@ pub struct BusAuthorsSummary {
 
 pub async fn get_bus_authors(State(state): State<AppState>) -> impl IntoResponse {
     let engine = state.engine.clone();
-    let result = tokio::task::spawn_blocking(move || {
-        engine.store().bus_author_seq_index_author_summary()
-    })
-    .await;
+    let result =
+        tokio::task::spawn_blocking(move || engine.store().bus_author_seq_index_author_summary())
+            .await;
 
     match result {
         Ok(Ok(rows)) => {

--- a/src/feed/schema.rs
+++ b/src/feed/schema.rs
@@ -227,7 +227,11 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
     ),
     (
         "node_status.v1.json",
-        r#"{
+        // Raw string uses `r##"..."##` so the embedded `"#/$defs/..."`
+        // JSON-pointer references inside the schema do not terminate
+        // the Rust string literal early (the `"#` sequence would end
+        // a single-`#` raw string).
+        r##"{
   "content_type": "node_status",
   "version": 1,
   "description": "Operational status published by an egregore node",
@@ -284,11 +288,60 @@ const DEFAULT_SCHEMAS: &[(&str, &str)] = &[
           "msgs_out_last_hour": { "type": "integer", "minimum": 0 }
         },
         "additionalProperties": false
-      }
+      },
+      "transport_health": { "$ref": "#/$defs/transport_health" }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "$defs": {
+      "transport_health": {
+        "type": "object",
+        "required": ["connected", "backend", "unreplicated_count", "inflight_publishes"],
+        "properties": {
+          "connected": { "type": "boolean" },
+          "backend": { "type": "string", "minLength": 1 },
+          "last_successful_publish": { "type": "string", "format": "date-time" },
+          "last_peer_contact": { "type": "string", "format": "date-time" },
+          "unreplicated_count": { "type": "integer", "minimum": 0 },
+          "inflight_publishes": { "type": "integer", "minimum": 0 },
+          "last_error": { "type": "string" },
+          "children": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/transport_health" }
+          },
+          "bridge_queues": { "$ref": "#/$defs/bridge_queues_health" }
+        },
+        "additionalProperties": false
+      },
+      "bridge_queues_health": {
+        "type": "object",
+        "required": [
+          "destination",
+          "depth_total",
+          "authors_backpressured",
+          "authors_active",
+          "backpressure_events_total",
+          "self_echo_total",
+          "ack_on_error_total",
+          "nats_redelivery_total"
+        ],
+        "properties": {
+          "destination": { "type": "string", "minLength": 1 },
+          "depth_total": { "type": "integer", "minimum": 0 },
+          "authors_backpressured": { "type": "integer", "minimum": 0 },
+          "authors_active": { "type": "integer", "minimum": 0 },
+          "backpressure_events_total": { "type": "integer", "minimum": 0 },
+          "self_echo_total": { "type": "integer", "minimum": 0 },
+          "oldest_queued_age_secs": { "type": "integer", "minimum": 0 },
+          "publish_in_flight_age_secs": { "type": "integer", "minimum": 0 },
+          "ack_on_error_total": { "type": "integer", "minimum": 0 },
+          "nats_redelivery_total": { "type": "integer", "minimum": 0 },
+          "last_error": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
   }
-}"#,
+}"##,
     ),
 ];
 

--- a/src/feed/store/messages.rs
+++ b/src/feed/store/messages.rs
@@ -13,6 +13,21 @@ use crate::identity::PublicId;
 
 use super::{content_type_name, FeedStore};
 
+/// Phase 2 Wave 5 Step 27 (amendment §G.3) — per-author summary of
+/// chain-gap state for the Prometheus metrics updater. One row per
+/// author that has at least one message with `chain_valid = 0` in the
+/// local `messages` table. Rows with `chain_valid = 1` never appear
+/// (the predecessor has been observed and the chain is intact).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainGapRow {
+    pub author: String,
+    /// Count of messages with `chain_valid = 0` for this author.
+    pub gap_count: u64,
+    /// Timestamp of the OLDEST chain-invalid message for this author.
+    /// Feeds `egregore_chain_gap_oldest_seconds{author}`.
+    pub oldest: DateTime<Utc>,
+}
+
 impl FeedStore {
     // ---- Message operations ----
 
@@ -188,6 +203,52 @@ impl FeedStore {
             params![chain_valid as i32, hash],
         )?;
         Ok(())
+    }
+
+    /// Per-author chain-gap summary (amendment §G.3 #2, #3). Returns
+    /// one row per author that has at least one message with
+    /// `chain_valid = 0` in the local store, carrying the count of
+    /// such messages + the timestamp of the oldest one.
+    ///
+    /// Feeds the Prometheus updater in Step 27, which writes
+    /// `egregore_chain_gap_count{author}` and
+    /// `egregore_chain_gap_oldest_seconds{author}` gauges from the
+    /// resulting rows. Authors with no chain_invalid messages are
+    /// omitted; operators rely on the absence of a label (or a
+    /// zero value on a label that was previously set) to distinguish
+    /// healthy from gap-bearing authors.
+    pub fn get_chain_gap_summary(&self) -> Result<Vec<ChainGapRow>> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT author, COUNT(*) AS gap_count, MIN(timestamp) AS oldest
+             FROM messages
+             WHERE chain_valid = 0
+             GROUP BY author
+             ORDER BY author",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                let author: String = row.get(0)?;
+                let count_i: i64 = row.get(1)?;
+                let oldest_s: String = row.get(2)?;
+                Ok((author, count_i, oldest_s))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        rows.into_iter()
+            .map(|(author, count_i, oldest_s)| {
+                let oldest = DateTime::parse_from_rfc3339(&oldest_s)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .map_err(|e| EgreError::Config {
+                        reason: format!("invalid messages.timestamp: {oldest_s}: {e}"),
+                    })?;
+                Ok(ChainGapRow {
+                    author,
+                    gap_count: count_i as u64,
+                    oldest,
+                })
+            })
+            .collect()
     }
 
     /// Check if a message's chain is validated.
@@ -880,5 +941,118 @@ mod tests {
 
         assert_eq!(incoming, 1);
         assert_eq!(outgoing, 1);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 2 Wave 5 Step 27 (amendment §G.3) — chain-gap summary.
+    // These tests pin the SQL projection that feeds the Prometheus
+    // `egregore_chain_gap_count{author}` and
+    // `egregore_chain_gap_oldest_seconds{author}` gauges.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn chain_gap_summary_empty_when_all_valid() {
+        // No chain_invalid messages in the store => summary is empty.
+        let store = FeedStore::open_memory().unwrap();
+        let m1 = make_test_message("@alice.ed25519", 1, None);
+        let m2 = make_test_message("@alice.ed25519", 2, Some("hash_@alice.ed25519_1"));
+        store.insert_message(&m1, true).unwrap();
+        store.insert_message(&m2, true).unwrap();
+
+        let summary = store.get_chain_gap_summary().unwrap();
+        assert!(
+            summary.is_empty(),
+            "all messages chain_valid => summary must be empty; got: {summary:?}"
+        );
+    }
+
+    #[test]
+    fn chain_gap_summary_reports_invalid_count_per_author() {
+        // Two authors, each with a mix of valid + invalid messages.
+        let store = FeedStore::open_memory().unwrap();
+        // Alice: one valid, two invalid.
+        store
+            .insert_message(&make_test_message("@alice.ed25519", 1, None), true)
+            .unwrap();
+        store
+            .insert_message(&make_test_message("@alice.ed25519", 5, None), false)
+            .unwrap();
+        store
+            .insert_message(&make_test_message("@alice.ed25519", 6, None), false)
+            .unwrap();
+        // Bob: one invalid.
+        store
+            .insert_message(&make_test_message("@bob.ed25519", 3, None), false)
+            .unwrap();
+
+        let summary = store.get_chain_gap_summary().unwrap();
+        assert_eq!(summary.len(), 2, "two authors with gaps => two rows");
+
+        let alice = summary
+            .iter()
+            .find(|r| r.author == "@alice.ed25519")
+            .expect("alice must appear");
+        assert_eq!(alice.gap_count, 2, "alice has two chain_invalid messages");
+
+        let bob = summary
+            .iter()
+            .find(|r| r.author == "@bob.ed25519")
+            .expect("bob must appear");
+        assert_eq!(bob.gap_count, 1, "bob has one chain_invalid message");
+    }
+
+    #[test]
+    fn chain_gap_summary_reports_oldest_timestamp_per_author() {
+        // Two invalid messages with distinct timestamps; summary must
+        // surface the OLDEST (min) for the oldest_seconds metric.
+        let store = FeedStore::open_memory().unwrap();
+
+        let older = Utc::now() - chrono::Duration::hours(2);
+        let newer = Utc::now() - chrono::Duration::minutes(5);
+        let mut m_old = make_test_message("@alice.ed25519", 10, None);
+        m_old.hash = "hash_@alice.ed25519_10".to_string();
+        m_old.timestamp = older;
+        let mut m_new = make_test_message("@alice.ed25519", 11, None);
+        m_new.hash = "hash_@alice.ed25519_11".to_string();
+        m_new.timestamp = newer;
+
+        store.insert_message(&m_old, false).unwrap();
+        store.insert_message(&m_new, false).unwrap();
+
+        let summary = store.get_chain_gap_summary().unwrap();
+        assert_eq!(summary.len(), 1);
+        let row = &summary[0];
+        assert_eq!(row.gap_count, 2);
+        // Allow minor sub-second drift due to rfc3339 round-trip.
+        assert!(
+            (row.oldest - older).num_seconds().abs() <= 1,
+            "oldest timestamp must be the older message; expected ~{older}, got {}",
+            row.oldest
+        );
+    }
+
+    #[test]
+    fn chain_gap_summary_promotes_when_predecessor_ingests() {
+        // Insert a gap message (chain_valid=false), assert summary has 1.
+        // Then flip chain_valid via `set_chain_valid`, assert the author
+        // drops out of the summary.
+        let store = FeedStore::open_memory().unwrap();
+        let gap = make_test_message("@alice.ed25519", 2, Some("missing-hash"));
+        store.insert_message(&gap, false).unwrap();
+
+        let before = store.get_chain_gap_summary().unwrap();
+        assert_eq!(before.len(), 1, "one author with a gap before promotion");
+        assert_eq!(before[0].gap_count, 1);
+
+        // Simulate predecessor arrival → promotion.
+        store
+            .set_chain_valid("hash_@alice.ed25519_2", true)
+            .unwrap();
+
+        let after = store.get_chain_gap_summary().unwrap();
+        assert!(
+            after.is_empty(),
+            "after promotion, author has zero gaps and drops out; got: {after:?}"
+        );
     }
 }

--- a/src/feed/store/pending.rs
+++ b/src/feed/store/pending.rs
@@ -56,6 +56,18 @@ pub struct AuthorActivityRow {
     pub last_indexed_at: DateTime<Utc>,
 }
 
+/// Per-author row including the author's highest indexed
+/// `(author_seq, stream_seq)` alongside `last_indexed_at`. Feeds
+/// scry's `/v1/transport/bus/authors` endpoint (amendment §C.14).
+/// Distinct from `AuthorActivityRow` which is author-silence-only.
+#[derive(Debug, Clone)]
+pub struct BusAuthorSummaryRow {
+    pub author: String,
+    pub last_indexed_at: DateTime<Utc>,
+    pub author_seq: u64,
+    pub stream_seq: u64,
+}
+
 /// Stream identity marker (amendment §G.1). Persisted on first index
 /// population; compared against live `stream.info()` on startup.
 #[derive(Debug, Clone)]
@@ -305,6 +317,52 @@ impl FeedStore {
                 Ok(AuthorActivityRow {
                     author,
                     last_indexed_at,
+                })
+            })
+            .collect()
+    }
+
+    /// Per-author summary projecting `(author_seq, stream_seq,
+    /// last_indexed_at)` for the author's highest indexed seq pair.
+    /// Feeds scry's `/v1/transport/bus/authors` endpoint (amendment
+    /// §C.14). Ordered by `last_indexed_at DESC` so operators see the
+    /// most recently active authors first.
+    pub fn bus_author_seq_index_author_summary(&self) -> Result<Vec<BusAuthorSummaryRow>> {
+        let conn = self.conn();
+        // The subquery picks the row with the largest author_seq per
+        // author; we then join with the outer to read stream_seq +
+        // indexed_at from that same row. GROUP BY with MAX(..) +
+        // correlated scan keeps things in a single statement.
+        let mut stmt = conn.prepare(
+            "SELECT i.author, i.author_seq, i.stream_seq, i.indexed_at
+             FROM bus_author_seq_index i
+             INNER JOIN (
+                 SELECT author, MAX(author_seq) AS max_seq
+                 FROM bus_author_seq_index
+                 GROUP BY author
+             ) m ON m.author = i.author AND m.max_seq = i.author_seq
+             ORDER BY i.indexed_at DESC",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                let author: String = row.get(0)?;
+                let author_seq_i: i64 = row.get(1)?;
+                let stream_seq_i: i64 = row.get(2)?;
+                let indexed_s: String = row.get(3)?;
+                Ok((author, author_seq_i, stream_seq_i, indexed_s))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        rows.into_iter()
+            .map(|(author, aseq, sseq, s)| {
+                let last_indexed_at = parse_rfc3339(&s).ok_or_else(|| EgreError::Config {
+                    reason: format!("invalid bus_author_seq_index.indexed_at: {s}"),
+                })?;
+                Ok(BusAuthorSummaryRow {
+                    author,
+                    last_indexed_at,
+                    author_seq: aseq as u64,
+                    stream_seq: sseq as u64,
                 })
             })
             .collect()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1114,6 +1114,15 @@ async fn main() -> anyhow::Result<()> {
                 tokio::time::sleep(update_interval).await;
             }
         });
+
+        // Phase 2 Wave 5 Step 27 — transport + bridge + chain-gap
+        // gauges. Separate task from the db-size loop because it runs
+        // on a different cadence (30s vs 60s) and reads from two
+        // distinct subsystems (transport_health + store projections).
+        let transport_metrics_engine = engine.clone();
+        tokio::spawn(async move {
+            egregore::metrics::run_transport_metrics_updater(transport_metrics_engine).await;
+        });
     }
 
     if config.node_status_enabled {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -319,8 +319,7 @@ use crate::feed::engine::FeedEngine;
 /// Default poll interval for the transport metrics updater. Chosen to
 /// match the scry `useBusAuthors` polling cadence (§C.14); bridge
 /// gauges and chain-gap metrics share this tick.
-pub const TRANSPORT_METRICS_INTERVAL: std::time::Duration =
-    std::time::Duration::from_secs(30);
+pub const TRANSPORT_METRICS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Drive the transport metrics families from `engine.transport_health()`
 /// and the store's chain-gap + author-activity projections. Returns
@@ -361,10 +360,8 @@ pub async fn update_transport_metrics_once(engine: &Arc<FeedEngine>) {
 
     // 2. Chain-gap summary → per-author gauges.
     let engine_for_gaps = engine.clone();
-    let chain_result = tokio::task::spawn_blocking(move || {
-        engine_for_gaps.store().get_chain_gap_summary()
-    })
-    .await;
+    let chain_result =
+        tokio::task::spawn_blocking(move || engine_for_gaps.store().get_chain_gap_summary()).await;
     match chain_result {
         Ok(Ok(rows)) => {
             let now = Utc::now();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -122,6 +122,318 @@ pub fn set_db_size(size_bytes: u64) {
     gauge!("egregore_db_size_bytes").set(size_bytes as f64);
 }
 
+// ============================================================================
+// Phase 2 Wave 5 Step 27 — Transport + Bridge Observability Metrics
+// ============================================================================
+//
+// All families below are populated by a single background task spawned
+// from `main.rs` (see `run_transport_metrics_updater`). The task polls
+// `engine.transport_health()`, `get_chain_gap_summary`, and
+// `bus_author_seq_index_latest_author_activity` every 30 seconds and
+// writes the corresponding gauge/counter values.
+//
+// Cardinality:
+// - `direction`: bounded (composite children count; typically 2).
+// - `destination`: bounded (per-direction, typically one per child).
+// - `author`: Ed25519 pubkey — intentionally UNBOUNDED for operator-
+//   side observability per amendment §C.14 + §G.3. The pubkey IS the
+//   author's identity; no PII scrubbing applies here the way it does
+//   to `last_error` strings (A2 guidance). Deployments concerned
+//   about metric cardinality should configure their Prometheus
+//   scraping to drop the `author` label — see `docs/deployment/bus.md`
+//   when that document lands (Step 28).
+
+// ---- Bridge gauges ----
+
+/// `egregore_bridge_queue_depth{direction, destination}` — per-
+/// direction total depth (sum over authors).
+pub fn set_bridge_queue_depth(direction: &str, destination: &str, depth: u64) {
+    gauge!(
+        "egregore_bridge_queue_depth",
+        "direction" => direction.to_string(),
+        "destination" => destination.to_string()
+    )
+    .set(depth as f64);
+}
+
+/// `egregore_bridge_authors_backpressured{direction}` — count of
+/// backpressured author queues in a direction.
+pub fn set_bridge_authors_backpressured(direction: &str, count: u64) {
+    gauge!(
+        "egregore_bridge_authors_backpressured",
+        "direction" => direction.to_string()
+    )
+    .set(count as f64);
+}
+
+/// `egregore_bridge_authors_active{direction}` — count of non-empty
+/// author queues in a direction.
+pub fn set_bridge_authors_active(direction: &str, count: u64) {
+    gauge!(
+        "egregore_bridge_authors_active",
+        "direction" => direction.to_string()
+    )
+    .set(count as f64);
+}
+
+/// `egregore_bridge_oldest_queued_age_seconds{direction}` — sourced
+/// from `BridgeQueuesHealth.oldest_queued_age_secs` when `Some`. When
+/// `None` the gauge is unset (not zeroed) so operators can distinguish
+/// "no queue" from "queue age = 0".
+pub fn set_bridge_oldest_queued_age_secs(direction: &str, age_secs: u64) {
+    gauge!(
+        "egregore_bridge_oldest_queued_age_seconds",
+        "direction" => direction.to_string()
+    )
+    .set(age_secs as f64);
+}
+
+/// `egregore_bridge_publish_in_flight_age_seconds{direction}` —
+/// sourced from `BridgeQueuesHealth.publish_in_flight_age_secs`.
+pub fn set_bridge_publish_in_flight_age_secs(direction: &str, age_secs: u64) {
+    gauge!(
+        "egregore_bridge_publish_in_flight_age_seconds",
+        "direction" => direction.to_string()
+    )
+    .set(age_secs as f64);
+}
+
+// ---- Bridge counters ----
+//
+// These wrap the monotonic counters exposed on `BridgeQueuesHealth`.
+// The underlying Prometheus registry stores its own monotonic counter,
+// so we bridge by computing the delta since the last observation.
+// `set_*_counter_absolute` makes the intent explicit.
+
+/// Monotonic counter of upstream-ingress block events. `absolute_total`
+/// is the value currently on `BridgeQueuesHealth`; we convert to a
+/// delta against our local shadow so the Prometheus counter increments
+/// correctly.
+pub fn set_bridge_backpressure_events_absolute(direction: &str, absolute_total: u64) {
+    set_counter_delta(
+        "egregore_bridge_backpressure_events_total",
+        direction,
+        absolute_total,
+    );
+}
+
+pub fn set_bridge_ack_on_error_absolute(direction: &str, absolute_total: u64) {
+    set_counter_delta(
+        "egregore_bridge_ack_on_error_total",
+        direction,
+        absolute_total,
+    );
+}
+
+pub fn set_bridge_nats_redelivery_absolute(direction: &str, absolute_total: u64) {
+    set_counter_delta(
+        "egregore_bridge_nats_redelivery_total",
+        direction,
+        absolute_total,
+    );
+}
+
+pub fn set_bridge_self_echo_absolute(direction: &str, absolute_total: u64) {
+    set_counter_delta("egregore_bridge_self_echo_total", direction, absolute_total);
+}
+
+// Internal: track last-observed absolute value per (metric_name, direction)
+// so the poller can emit the correct delta to the monotonic counter.
+static COUNTER_SHADOWS: OnceLock<
+    std::sync::Mutex<std::collections::HashMap<(String, String), u64>>,
+> = OnceLock::new();
+
+fn set_counter_delta(metric_name: &'static str, direction: &str, absolute_total: u64) {
+    let shadows =
+        COUNTER_SHADOWS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let key = (metric_name.to_string(), direction.to_string());
+    let delta = {
+        let mut guard = shadows
+            .lock()
+            .expect("metrics counter shadow mutex poisoned");
+        let prev = guard.get(&key).copied().unwrap_or(0);
+        // Handle resets: if absolute_total < prev (e.g., process restart
+        // of the source without resetting the Prometheus exporter),
+        // treat the new value as the delta (not negative).
+        let delta = absolute_total.saturating_sub(prev);
+        guard.insert(key, absolute_total);
+        delta
+    };
+    if delta > 0 {
+        counter!(
+            metric_name,
+            "direction" => direction.to_string()
+        )
+        .increment(delta);
+    }
+}
+
+// ---- Per-author gauges (amendment §G.3) ----
+
+/// `egregore_transport_nats_author_silence_seconds{author}` —
+/// amendment §G.3 #1: time since we last saw a bus-sourced message
+/// from this author. Rising values across many authors indicate
+/// broker outage OR consumer stall; rising on a single author is
+/// author-side silence.
+pub fn set_author_silence_secs(author: &str, secs: u64) {
+    gauge!(
+        "egregore_transport_nats_author_silence_seconds",
+        "author" => author.to_string()
+    )
+    .set(secs as f64);
+}
+
+/// `egregore_chain_gap_count{author}` — amendment §G.3 #2: per-author
+/// count of messages with `chain_valid = 0` in local SQLite. Rising
+/// means genuine chain-gap state (predecessor missing), independent
+/// of which transport delivered the message.
+pub fn set_chain_gap_count(author: &str, count: u64) {
+    gauge!(
+        "egregore_chain_gap_count",
+        "author" => author.to_string()
+    )
+    .set(count as f64);
+}
+
+/// `egregore_chain_gap_oldest_seconds{author}` — amendment §G.3 #3:
+/// per-author age of oldest chain_invalid message. A value exceeding
+/// the retention interval suggests the gap is permanent.
+pub fn set_chain_gap_oldest_secs(author: &str, secs: u64) {
+    gauge!(
+        "egregore_chain_gap_oldest_seconds",
+        "author" => author.to_string()
+    )
+    .set(secs as f64);
+}
+
+// ============================================================================
+// Phase 2 Wave 5 Step 27 — background metrics updater task.
+// ============================================================================
+
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use crate::feed::engine::FeedEngine;
+
+/// Default poll interval for the transport metrics updater. Chosen to
+/// match the scry `useBusAuthors` polling cadence (§C.14); bridge
+/// gauges and chain-gap metrics share this tick.
+pub const TRANSPORT_METRICS_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
+/// Drive the transport metrics families from `engine.transport_health()`
+/// and the store's chain-gap + author-activity projections. Returns
+/// immediately if `metrics.enabled` is false at start-up; otherwise
+/// loops indefinitely on the provided interval.
+///
+/// Call sites: spawned once from `main.rs` after
+/// `init_metrics(..)` succeeds. The spawn is conditional on
+/// `config.metrics.enabled` to keep the tick off when metrics are
+/// disabled.
+pub async fn run_transport_metrics_updater(engine: Arc<FeedEngine>) {
+    run_transport_metrics_updater_with_interval(engine, TRANSPORT_METRICS_INTERVAL).await;
+}
+
+/// Test-seam variant accepting a custom interval; production call
+/// paths use `run_transport_metrics_updater`.
+pub async fn run_transport_metrics_updater_with_interval(
+    engine: Arc<FeedEngine>,
+    interval: std::time::Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    // Align to "on start" + regular cadence; `set_missed_tick_behavior`
+    // avoids thunder after a long stall.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        update_transport_metrics_once(&engine).await;
+    }
+}
+
+/// One tick of the updater — broken out so tests (and main.rs during
+/// testing) can drive it deterministically without spinning the loop.
+pub async fn update_transport_metrics_once(engine: &Arc<FeedEngine>) {
+    // 1. Transport health → bridge + leaf gauges.
+    if let Some(health) = engine.transport_health() {
+        update_bridge_metrics_from_health(&health);
+    }
+
+    // 2. Chain-gap summary → per-author gauges.
+    let engine_for_gaps = engine.clone();
+    let chain_result = tokio::task::spawn_blocking(move || {
+        engine_for_gaps.store().get_chain_gap_summary()
+    })
+    .await;
+    match chain_result {
+        Ok(Ok(rows)) => {
+            let now = Utc::now();
+            for row in rows {
+                set_chain_gap_count(&row.author, row.gap_count);
+                let age = (now - row.oldest).num_seconds().max(0) as u64;
+                set_chain_gap_oldest_secs(&row.author, age);
+            }
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "get_chain_gap_summary failed; skipping tick");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "chain-gap task failed; skipping tick");
+        }
+    }
+
+    // 3. Bus author activity → author-silence gauges.
+    let engine_for_authors = engine.clone();
+    let activity_result = tokio::task::spawn_blocking(move || {
+        engine_for_authors
+            .store()
+            .bus_author_seq_index_latest_author_activity()
+    })
+    .await;
+    match activity_result {
+        Ok(Ok(rows)) => {
+            let now = Utc::now();
+            for row in rows {
+                let silence = (now - row.last_indexed_at).num_seconds().max(0) as u64;
+                set_author_silence_secs(&row.author, silence);
+            }
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "bus_author_seq_index_latest_author_activity failed; skipping tick");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "author-silence task failed; skipping tick");
+        }
+    }
+}
+
+/// Walk a `TransportHealth` tree and write bridge metrics for each
+/// child that carries `bridge_queues` (i.e., each composite child-as-
+/// destination). The top-level aggregate has no `bridge_queues` of its
+/// own — only its children do — so a single-transport deployment is a
+/// no-op here. Zero-child deployments never call this function.
+fn update_bridge_metrics_from_health(health: &crate::transport::health::TransportHealth) {
+    for child in &health.children {
+        if let Some(queues) = &child.bridge_queues {
+            let direction = child.backend;
+            let destination = queues.destination.as_str();
+            set_bridge_queue_depth(direction, destination, queues.depth_total);
+            set_bridge_authors_backpressured(direction, queues.authors_backpressured);
+            set_bridge_authors_active(direction, queues.authors_active);
+            if let Some(age) = queues.oldest_queued_age_secs {
+                set_bridge_oldest_queued_age_secs(direction, age);
+            }
+            if let Some(age) = queues.publish_in_flight_age_secs {
+                set_bridge_publish_in_flight_age_secs(direction, age);
+            }
+            set_bridge_backpressure_events_absolute(direction, queues.backpressure_events_total);
+            set_bridge_ack_on_error_absolute(direction, queues.ack_on_error_total);
+            set_bridge_nats_redelivery_absolute(direction, queues.nats_redelivery_total);
+            set_bridge_self_echo_absolute(direction, queues.self_echo_total);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/status.rs
+++ b/src/status.rs
@@ -11,6 +11,7 @@ use crate::feed::profile_lifecycle::{peer_profile_validity, SystemClock};
 use crate::gossip::health::{PeerHealthStatus, DIRECT_OBSERVATION_MARKER};
 use crate::gossip::registry::ConnectionRegistry;
 use crate::identity::{Identity, PublicId};
+use crate::transport::health::TransportHealth;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct NodeStatusMessage {
@@ -23,6 +24,14 @@ pub struct NodeStatusMessage {
     pub peers: NodeStatusPeers,
     pub storage: NodeStatusStorage,
     pub throughput: NodeStatusThroughput,
+
+    /// Phase 2 Wave 5 Step 25: transport health from
+    /// `engine.transport_health()`. Optional; omitted from serialized
+    /// output when `None` (single-transport-less test harness OR
+    /// pre-Phase-2 consumer). Lock-stepped with the `node_status/v1`
+    /// JSON Schema's `transport_health` property (see `src/feed/schema.rs`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_health: Option<TransportHealth>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -170,6 +179,12 @@ pub fn build_node_status(
         .collect();
     health.sort_by(|a, b| a.peer.cmp(&b.peer));
 
+    // Phase 2 Wave 5 Step 25: surface transport health on node_status
+    // alongside /v1/status. `transport_health()` returns None for test
+    // harnesses with no attached transport; the optional field is
+    // omitted from serialized output in that case.
+    let transport_health = engine.transport_health();
+
     Ok(NodeStatusMessage {
         msg_type: "node_status".to_string(),
         node: identity.public_id().0,
@@ -190,6 +205,7 @@ pub fn build_node_status(
             msgs_in_last_hour,
             msgs_out_last_hour,
         },
+        transport_health,
     })
 }
 

--- a/tests/peer_profile_filter.rs
+++ b/tests/peer_profile_filter.rs
@@ -424,9 +424,7 @@ async fn node_status_without_transport_health_still_valid() {
             None,
             vec!["node_status".to_string()],
         )
-        .expect(
-            "node_status without transport_health must pass schema validation (back-compat)",
-        );
+        .expect("node_status without transport_health must pass schema validation (back-compat)");
     assert_eq!(message.schema_id.as_deref(), Some("node_status/v1"));
 
     let _ = std::fs::remove_dir_all(&temp_dir);

--- a/tests/peer_profile_filter.rs
+++ b/tests/peer_profile_filter.rs
@@ -232,3 +232,202 @@ fn messages_from_expired_peer_still_ingest() {
     assert_eq!(stored.hash, content_msg.hash);
     assert_eq!(stored.author, peer_identity.public_id());
 }
+
+// ----------------------------------------------------------------------
+// Phase 2 Wave 5 Step 25 — node_status/v1 lock-step with TransportHealth.
+// Same pattern as the profile_expired lock-step test above: the Rust
+// struct's `transport_health` field MUST be permitted by the embedded
+// JSON Schema (src/feed/schema.rs), including the nested
+// `BridgeQueuesHealth` sub-schema for composite/bridge deployments.
+// ----------------------------------------------------------------------
+
+use egregore::transport::health::{BridgeQueuesHealth, TransportHealth};
+
+#[tokio::test]
+async fn node_status_with_transport_health_validates_against_schema() {
+    // Constructs a fully-populated `TransportHealth` — including
+    // composite children with `bridge_queues` — and asserts
+    // `publish_with_schema("node_status/v1", ...)` accepts it.
+    //
+    // This exercises the deepest branch of the schema: the
+    // `$defs/transport_health` recursive reference (`children[]`) and
+    // the `$defs/bridge_queues_health` branch for per-direction metrics.
+    let self_identity = Identity::generate();
+    let temp_dir = std::env::temp_dir().join(format!(
+        "egregore_step25_with_th_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    let store = FeedStore::open_memory().unwrap();
+    // Use with_schemas_dir so default schemas (including updated
+    // node_status/v1) get written into a fresh dir and loaded.
+    let engine = FeedEngine::with_schemas_dir(store, &temp_dir);
+
+    let now = Utc::now();
+    let child_bus = TransportHealth {
+        connected: true,
+        backend: "nats",
+        last_successful_publish: Some(now),
+        last_peer_contact: Some(now),
+        unreplicated_count: 3,
+        inflight_publishes: 1,
+        last_error: None,
+        children: vec![],
+        bridge_queues: Some(BridgeQueuesHealth {
+            destination: "nats".to_string(),
+            depth_total: 12,
+            authors_backpressured: 0,
+            authors_active: 2,
+            backpressure_events_total: 0,
+            self_echo_total: 4,
+            oldest_queued_age_secs: Some(7),
+            publish_in_flight_age_secs: Some(1),
+            ack_on_error_total: 0,
+            nats_redelivery_total: 0,
+            last_error: None,
+        }),
+    };
+    let child_gossip = TransportHealth {
+        connected: true,
+        backend: "gossip",
+        last_successful_publish: Some(now),
+        last_peer_contact: Some(now),
+        unreplicated_count: 0,
+        inflight_publishes: 0,
+        last_error: None,
+        children: vec![],
+        bridge_queues: Some(BridgeQueuesHealth {
+            destination: "gossip".to_string(),
+            depth_total: 0,
+            authors_backpressured: 0,
+            authors_active: 0,
+            backpressure_events_total: 0,
+            self_echo_total: 0,
+            oldest_queued_age_secs: None,
+            publish_in_flight_age_secs: None,
+            ack_on_error_total: 0,
+            nats_redelivery_total: 0,
+            last_error: None,
+        }),
+    };
+    let composite = TransportHealth {
+        connected: true,
+        backend: "composite",
+        last_successful_publish: Some(now),
+        last_peer_contact: Some(now),
+        unreplicated_count: 3,
+        inflight_publishes: 1,
+        last_error: None,
+        children: vec![child_bus, child_gossip],
+        bridge_queues: None,
+    };
+
+    let status = egregore::status::NodeStatusMessage {
+        msg_type: "node_status".to_string(),
+        node: self_identity.public_id().0,
+        ts: now,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        uptime_secs: 42,
+        peers: egregore::status::NodeStatusPeers {
+            connected: 0,
+            known: 0,
+            health: vec![],
+        },
+        storage: egregore::status::NodeStatusStorage {
+            bytes: 0,
+            message_count: 0,
+            feed_count: 0,
+        },
+        throughput: egregore::status::NodeStatusThroughput {
+            msgs_in_last_hour: 0,
+            msgs_out_last_hour: 0,
+        },
+        transport_health: Some(composite),
+    };
+
+    let status_json = serde_json::to_value(&status).expect("serialize node_status");
+
+    // Load-bearing assertion: schema accepts full TransportHealth shape.
+    let message = engine
+        .publish_with_schema(
+            &self_identity,
+            status_json,
+            Some("node_status/v1".to_string()),
+            None,
+            vec!["node_status".to_string()],
+        )
+        .expect("node_status with full TransportHealth must pass schema validation");
+    assert_eq!(message.schema_id.as_deref(), Some("node_status/v1"));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn node_status_without_transport_health_still_valid() {
+    // Back-compat guardrail: a node_status message WITHOUT the new
+    // `transport_health` field (the Phase-1 shape) MUST still validate.
+    // `#[serde(default, skip_serializing_if = "Option::is_none")]` +
+    // the schema's `transport_health` NOT appearing in `required` are
+    // the load-bearing bits this test pins.
+    let self_identity = Identity::generate();
+    let temp_dir = std::env::temp_dir().join(format!(
+        "egregore_step25_without_th_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    let store = FeedStore::open_memory().unwrap();
+    let engine = FeedEngine::with_schemas_dir(store, &temp_dir);
+
+    let status = egregore::status::NodeStatusMessage {
+        msg_type: "node_status".to_string(),
+        node: self_identity.public_id().0,
+        ts: Utc::now(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        uptime_secs: 0,
+        peers: egregore::status::NodeStatusPeers {
+            connected: 0,
+            known: 0,
+            health: vec![],
+        },
+        storage: egregore::status::NodeStatusStorage {
+            bytes: 0,
+            message_count: 0,
+            feed_count: 0,
+        },
+        throughput: egregore::status::NodeStatusThroughput {
+            msgs_in_last_hour: 0,
+            msgs_out_last_hour: 0,
+        },
+        transport_health: None,
+    };
+
+    let status_json = serde_json::to_value(&status).expect("serialize node_status");
+    // Confirm the None serializes to "field absent" (not "null").
+    assert!(
+        status_json.get("transport_health").is_none(),
+        "transport_health: None must be omitted from JSON; got: {status_json}"
+    );
+
+    let message = engine
+        .publish_with_schema(
+            &self_identity,
+            status_json,
+            Some("node_status/v1".to_string()),
+            None,
+            vec!["node_status".to_string()],
+        )
+        .expect(
+            "node_status without transport_health must pass schema validation (back-compat)",
+        );
+    assert_eq!(message.schema_id.as_deref(), Some("node_status/v1"));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}

--- a/tests/transport_endpoints.rs
+++ b/tests/transport_endpoints.rs
@@ -1,0 +1,157 @@
+//! Phase 2 Wave 5 Step 26 — backend endpoints for scry's bridge panel
+//! (amendment §C.14).
+//!
+//! Three tests — kept small because these endpoints are thin wrappers
+//! over CRUD helpers that already have unit-test coverage in
+//! `src/feed/store/pending.rs`:
+//!
+//! 1. `/v1/transport/pending` count matches `pending_forwarding_count`.
+//! 2. `/v1/transport/bus/authors` returns the expected rows when the
+//!    `bus_author_seq_index` is populated.
+//! 3. `/v1/transport/bus/authors` returns an empty list on a fresh
+//!    node (no entries in `bus_author_seq_index`).
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use egregore::api::{mcp_registry, router_with_mcp, AppState};
+use egregore::config::Config;
+use egregore::feed::engine::FeedEngine;
+use egregore::feed::store::FeedStore;
+use egregore::identity::Identity;
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::ServiceExt;
+
+fn create_app() -> (Arc<FeedEngine>, axum::Router) {
+    let identity = Identity::generate();
+    let store = FeedStore::open_memory().unwrap();
+    let engine = Arc::new(FeedEngine::new(store));
+    let config = Config {
+        api_auth_enabled: false,
+        ..Config::default()
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let blob_store = egregore::blob::BlobStore::new(tmp.path());
+    let state = AppState {
+        identity,
+        engine: engine.clone(),
+        config: Arc::new(config),
+        started_at: Instant::now(),
+        mcp_registry: mcp_registry::create_registry(),
+        blob_store,
+    };
+    (engine, router_with_mcp(state, false))
+}
+
+async fn get_json(app: axum::Router, uri: &str) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, v)
+}
+
+#[tokio::test]
+async fn transport_pending_count_matches_pending_forwarding_count() {
+    let (engine, app) = create_app();
+
+    // Enqueue 2 pending messages under transport_id = "bus".
+    let author = Identity::generate();
+    let msg1 = engine
+        .publish(
+            &author,
+            serde_json::json!({"type":"message","text":"one"}),
+            None,
+            vec![],
+        )
+        .unwrap();
+    let msg2 = engine
+        .publish(
+            &author,
+            serde_json::json!({"type":"message","text":"two"}),
+            None,
+            vec![],
+        )
+        .unwrap();
+    engine
+        .store()
+        .pending_forwarding_enqueue("bus", &msg1)
+        .unwrap();
+    engine
+        .store()
+        .pending_forwarding_enqueue("bus", &msg2)
+        .unwrap();
+
+    let (status, body) = get_json(app, "/v1/transport/pending?transport_id=bus").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["success"], true);
+    let data = &body["data"];
+    assert_eq!(
+        data["transport_id"], "bus",
+        "endpoint echoes queried transport_id"
+    );
+    assert_eq!(
+        data["count"], 2,
+        "count must match the store's pending_forwarding_count"
+    );
+    assert!(
+        data["rows"].as_array().unwrap().len() == 2,
+        "rows array should contain both pending entries"
+    );
+}
+
+#[tokio::test]
+async fn bus_authors_returns_expected_rows() {
+    let (engine, app) = create_app();
+
+    // Populate bus_author_seq_index with 2 authors.
+    engine
+        .store()
+        .bus_author_seq_index_insert("@alice.ed25519", 1, 100)
+        .unwrap();
+    engine
+        .store()
+        .bus_author_seq_index_insert("@alice.ed25519", 2, 101)
+        .unwrap();
+    engine
+        .store()
+        .bus_author_seq_index_insert("@bob.ed25519", 1, 102)
+        .unwrap();
+
+    let (status, body) = get_json(app, "/v1/transport/bus/authors").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["success"], true);
+    let rows = body["data"]["rows"].as_array().expect("rows array");
+    assert_eq!(rows.len(), 2, "two distinct authors expected");
+
+    // Each row carries {author, last_indexed_at, author_seq, stream_seq}.
+    for row in rows {
+        assert!(row["author"].is_string());
+        assert!(row["last_indexed_at"].is_string());
+        assert!(row["author_seq"].is_number());
+        assert!(row["stream_seq"].is_number());
+    }
+}
+
+#[tokio::test]
+async fn bus_authors_empty_when_index_empty() {
+    let (_engine, app) = create_app();
+
+    // No inserts into bus_author_seq_index — fresh node.
+    let (status, body) = get_json(app, "/v1/transport/bus/authors").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["success"], true);
+    let rows = body["data"]["rows"].as_array().expect("rows array");
+    assert!(
+        rows.is_empty(),
+        "empty bus_author_seq_index must yield empty rows array"
+    );
+}


### PR DESCRIPTION
## Summary

Wave 5 of six. Surfaces transport health on `/v1/status` and signed `node_status`, adds two bus-specific REST endpoints, and wires Prometheus metrics including the amendment §G.3 three-metric split (author silence, chain-gap count, chain-gap oldest age).

## Commits

- **Step 24** (`bc1af37`) — `/v1/status` gains optional `transport: TransportHealth`. `#[serde(default, skip_serializing_if = "Option::is_none")]` preserves the Phase 1 response shape when `transport_count() == 0`.
- **Step 25** (`8629417`) — `NodeStatusMessage.transport_health: Option<TransportHealth>` + `node_status/v1` schema lock-step update. Bumped schema block to `r##"..."##` because JSON Pointer `#/$defs/...` sequences collide with single-`#` raw string terminator.
- **Step 26** (`4ed85c9`) — egregore routes + scry components. Two new endpoints: `GET /v1/transport/pending` and `GET /v1/transport/bus/authors`. Scry `BridgePanel` + `TransportHealthRow` + `BridgeQueueRow` committed to the scry repo (separate; not built via npm in this PR).
- **Step 27** (`27f19d4`) — Prometheus metric families + chain-gap metrics + per-30s updater task. Amendment §G.3 three-metric split lands intact.
- **fmt** (`dd47675`) — cargo fmt cleanup.

## Scope NOT in this wave

- Operator documentation (bus.md, bridge.md, DR runbook, etc.) — Wave 6.
- B.8 property test — Wave 6.
- hybrid.md deletion — Wave 6.

## Security-auditor amendments satisfied

- §A2 (PII scrubbing): `BridgeQueuesHealth.last_error` populates through `DirectionState.last_error` (Wave 3 scrubbed writes) — no new PII surface.
- §G.3 three-metric split: `egregore_transport_nats_author_silence_seconds{author}` (renamed from original chain-gap proposal), `egregore_chain_gap_count{author}` (true chain-gap via `chain_valid = 0`), `egregore_chain_gap_oldest_seconds{author}` (supplementary).

## Verification

- **cargo test**: **571 passed / 0 failed / 8 ignored** (+11 tests since Wave 4: 2 Step 24 + 2 Step 25 + 3 Step 26 integration + 4 Step 27 SQL helper tests).
- **cargo build --release**: clean
- **cargo clippy --all-targets --all-features -- -D warnings**: clean
- **cargo fmt --all --check**: clean

## Deviations (documented)

1. Scry UI tests skipped — scry harness not set up for our needs. Components written for manual verification against a live Phase 2 daemon. Scry commit `1a55188` lives in the scry repo master (separate repo).
2. Step 27 metrics uses a shadow-map pattern for counter increments (BridgeQueuesHealth carries absolute totals, Prometheus counters want deltas). Documented in `metrics.rs`.
3. Author labels on Prometheus metrics are Ed25519 pubkeys (unbounded cardinality). Documented; operators use Prometheus relabel rules to drop if needed.
4. Step 26 did NOT add a `/v1/groups?bus=true` filter (amendment §C.14 groups-panel enhancement). Requires knowing which consumer groups are bus-anchored — currently untracked. Flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)