### PR TITLE
2.0.1: refuse silent identity replacement on encrypted-key-only systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to egregore are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project follows [Semantic Versioning](https://semver.org/) post-1.0.
 
+## [2.0.1] - 2026-04-27
+
+### Fixed
+
+- **Refuse to silently mint a new identity when only `secret.key.enc` exists.** The 2.0.0 migration was documentation-only; an operator who upgraded without reading `CHANGELOG.md` would have `Identity::load_or_generate` mint a fresh keypair next to the orphaned encrypted key, silently changing the node's `public_id`. `load_or_generate` now refuses to start in that state, with an `EgreError::Config` whose message lists both safe actions: migrate the encrypted key to plaintext per the 2.0.0 migration steps, **or** delete/move `secret.key.enc` to deliberately start with a fresh identity.
+
+  Known limitation: the check uses `Path::exists()`, which returns `false` for a dangling symlink whose target is unmounted. A symlinked encrypted key on an unmounted volume could still slip past the guard. Treated as an acceptable trade-off for the single-operator deployment model; revisit if real deployments use symlinked key files.
+
 ## [2.0.0] - 2026-04-27
 
 ### ⚠ Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "egregore"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name = "egregore"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 description = "SSB-inspired decentralized knowledge sharing for LLMs"
 license = "MIT OR Apache-2.0"

--- a/src/identity/keys.rs
+++ b/src/identity/keys.rs
@@ -78,15 +78,38 @@ impl Identity {
     pub fn load_or_generate(identity_dir: &Path) -> Result<Self> {
         let key_path = identity_dir.join("secret.key");
         if key_path.exists() {
-            Self::load_unencrypted(&key_path)
-        } else {
-            let identity = Self::generate();
-            identity.save_unencrypted(&key_path)?;
-            // Also save public key for convenience
-            let pub_path = identity_dir.join("public.key");
-            std::fs::write(pub_path, identity.public_id().0.as_bytes())?;
-            Ok(identity)
+            return Self::load_unencrypted(&key_path);
         }
+
+        // Refuse to silently mint a new identity when an Argon2id-encrypted
+        // key from a pre-2.0 deployment exists alongside no plaintext key.
+        // Without this check, load_or_generate would happily generate a new
+        // keypair, the orphaned secret.key.enc would sit unused, and the
+        // node would publish under a different public ID — silent identity
+        // loss. See CHANGELOG.md (2.0.0) for migration steps.
+        let enc_path = identity_dir.join("secret.key.enc");
+        if enc_path.exists() {
+            return Err(EgreError::Config {
+                reason: format!(
+                    "found {} but no {}. Argon2id-encrypted keys are not supported in 2.0; \
+                     generating a new keypair would silently change this node's public ID. \
+                     Migration: on a pre-2.0 build, decrypt the key and save the plaintext \
+                     as {} with mode 0600. To intentionally start over with a fresh identity, \
+                     delete or move {} and restart. See CHANGELOG.md for details.",
+                    enc_path.display(),
+                    key_path.display(),
+                    key_path.display(),
+                    enc_path.display(),
+                ),
+            });
+        }
+
+        let identity = Self::generate();
+        identity.save_unencrypted(&key_path)?;
+        // Also save public key for convenience
+        let pub_path = identity_dir.join("public.key");
+        std::fs::write(pub_path, identity.public_id().0.as_bytes())?;
+        Ok(identity)
     }
 
     /// Get the raw secret key bytes (for Curve25519 conversion, etc.).
@@ -214,6 +237,65 @@ mod tests {
 
         // Same key loaded both times
         assert_eq!(id1.verifying_key(), id2.verifying_key());
+    }
+
+    #[test]
+    fn load_or_generate_refuses_when_only_encrypted_key_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity_dir = dir.path().join("identity");
+        std::fs::create_dir_all(&identity_dir).unwrap();
+
+        // Simulate a pre-2.0 deployment where only secret.key.enc exists.
+        let enc_path = identity_dir.join("secret.key.enc");
+        std::fs::write(&enc_path, b"ciphertext-not-decryptable-anymore").unwrap();
+
+        let result = Identity::load_or_generate(&identity_dir);
+        match result {
+            Err(EgreError::Config { reason }) => {
+                assert!(
+                    reason.contains("Argon2id-encrypted keys are not supported"),
+                    "error reason missing migration framing: {reason}"
+                );
+                assert!(
+                    reason.contains("delete or move"),
+                    "error reason missing fresh-start guidance: {reason}"
+                );
+            }
+            Err(other) => panic!("expected EgreError::Config, got: {other:?}"),
+            Ok(_) => panic!("expected guard to fire; identity was minted instead"),
+        }
+
+        // Guard must not have written either file: the orphan .enc is the
+        // only file we should see in the directory.
+        assert!(
+            !identity_dir.join("secret.key").exists(),
+            "guard fired but secret.key was still written"
+        );
+        assert!(
+            !identity_dir.join("public.key").exists(),
+            "guard fired but public.key was still written"
+        );
+    }
+
+    #[test]
+    fn load_or_generate_prefers_plaintext_when_both_files_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity_dir = dir.path().join("identity");
+        std::fs::create_dir_all(&identity_dir).unwrap();
+
+        // Plaintext is the contract; .enc is a stale leftover.
+        let plain = Identity::generate();
+        plain
+            .save_unencrypted(&identity_dir.join("secret.key"))
+            .unwrap();
+        std::fs::write(
+            identity_dir.join("secret.key.enc"),
+            b"stale-leftover-ciphertext",
+        )
+        .unwrap();
+
+        let loaded = Identity::load_or_generate(&identity_dir).unwrap();
+        assert_eq!(loaded.verifying_key(), plain.verifying_key());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Patch release closing the silent-identity-replacement footgun introduced by 2.0.0. The 2.0.0 release dropped Argon2id-encrypted key support and documented the migration in `CHANGELOG.md`, but `Identity::load_or_generate` still silently minted a fresh keypair when an operator had only `secret.key.enc` on disk — generating a brand-new `public_id` and orphaning every feed message signed by the old key.

This patch installs a runtime guard: if `secret.key.enc` exists alongside no `secret.key`, the daemon refuses to start with an `EgreError::Config` whose message lists both safe actions:

1. Migrate the encrypted key to plaintext per the 2.0.0 migration steps, **or**
2. Delete / move `secret.key.enc` to deliberately start with a fresh identity.

Reviewed by Codex (pair-review). Two rounds: round 1 surfaced the `Path::exists()` symlink false-negative and a missing "delete to start fresh" hint; round 2 confirmed all blockers cleared after addressing message clarity + test assertions. The symlink limitation is documented as a known trade-off in 2.0.1's CHANGELOG entry.

## Test plan

- [ ] CI: fmt + clippy + test + build + security audit
- [ ] New `load_or_generate_refuses_when_only_encrypted_key_present` test:
  - Asserts `Err(EgreError::Config)` (not just any error)
  - Asserts message text mentions Argon2id-encrypted keys + the "delete or move" alternative
  - Asserts no `secret.key` / `public.key` written when guard fires
- [ ] New `load_or_generate_prefers_plaintext_when_both_files_exist` test confirms a stale `.enc` next to a real plaintext key is harmless
- [ ] Existing 14 identity tests still pass (verified locally)