### PR TITLE
refactor: collapse boilerplate + hoist composite hooks onto Transport trait

### DIFF
--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -202,3 +202,40 @@ pub fn from_error(e: crate::error::EgreError) -> Response {
 
     (status, body).into_response()
 }
+
+/// Run a synchronous, blocking workload (typically a SQLite call) on Tokio's
+/// blocking pool and lift the standard error mapping out of every API
+/// handler:
+///
+/// - `Ok(Ok(value))` → `Ok(value)` for the caller's success path.
+/// - `Ok(Err(EgreError))` → `Err(from_error(e))`.
+/// - `Err(JoinError)` → logged with `ctx`, returned as `INTERNAL_SERVER_ERROR`.
+///
+/// Caller pattern:
+/// ```ignore
+/// let value = match run_blocking(move || engine.query(...), "failed to query").await {
+///     Ok(v) => v,
+///     Err(resp) => return resp,
+/// };
+/// ```
+///
+/// Or, if the handler's signature is `Result<Response, Response>`, just `?`.
+///
+/// Do NOT use this helper for handlers that need to introspect `EgreError`
+/// before converting it (e.g. group "already exists" → 409, status/health
+/// builders that intentionally degrade rather than fail). Those keep the
+/// inline `match`.
+pub async fn run_blocking<T, F>(f: F, ctx: &'static str) -> std::result::Result<T, Response>
+where
+    F: FnOnce() -> std::result::Result<T, crate::error::EgreError> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(Ok(t)) => Ok(t),
+        Ok(Err(e)) => Err(from_error(e)),
+        Err(join_err) => {
+            tracing::error!(error = %join_err, ctx, "blocking task join failure");
+            Err(err::<()>(StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ctx).into_response())
+        }
+    }
+}

--- a/src/api/routes_feed.rs
+++ b/src/api/routes_feed.rs
@@ -46,43 +46,41 @@ pub async fn get_feed(
     let identity = state.identity.clone();
     let include_self = params.include_self.unwrap_or(false);
     let self_id = state.identity.public_id();
+    let limit = params.limit;
+    let offset = params.offset;
 
-    let result = tokio::task::spawn_blocking(move || {
-        engine.query(&FeedQuery {
-            author: None,
-            exclude_author: if include_self { None } else { Some(self_id) },
-            content_type: params.content_type,
-            trace_id: params.trace_id,
-            tag: params.tag,
-            relates: params.relates,
-            limit: params.limit,
-            offset: params.offset,
-            ..Default::default()
-        })
-    })
-    .await;
+    let msgs = match response::run_blocking(
+        move || {
+            engine.query(&FeedQuery {
+                author: None,
+                exclude_author: if include_self { None } else { Some(self_id) },
+                content_type: params.content_type,
+                trace_id: params.trace_id,
+                tag: params.tag,
+                relates: params.relates,
+                limit,
+                offset,
+                ..Default::default()
+            })
+        },
+        "failed to query feed",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(msgs)) => {
-            let msgs: Vec<Message> = msgs
-                .into_iter()
-                .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
-                .collect();
-            let meta = response::ApiMetadata {
-                total: None,
-                limit: params.limit,
-                offset: params.offset,
-            };
-            response::ok_with_metadata(msgs, meta).into_response()
-        }
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to query feed",
-        )
-        .into_response(),
-    }
+    let msgs: Vec<Message> = msgs
+        .into_iter()
+        .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
+        .collect();
+    let meta = response::ApiMetadata {
+        total: None,
+        limit,
+        offset,
+    };
+    response::ok_with_metadata(msgs, meta).into_response()
 }
 
 pub async fn get_feed_by_author(
@@ -93,34 +91,30 @@ pub async fn get_feed_by_author(
     let engine = state.engine.clone();
     let identity = state.identity.clone();
 
-    let result = tokio::task::spawn_blocking(move || {
-        engine.query(&FeedQuery {
-            author: Some(PublicId(author)),
-            content_type: params.content_type,
-            trace_id: params.trace_id,
-            limit: params.limit,
-            offset: params.offset,
-            ..Default::default()
-        })
-    })
-    .await;
+    let msgs = match response::run_blocking(
+        move || {
+            engine.query(&FeedQuery {
+                author: Some(PublicId(author)),
+                content_type: params.content_type,
+                trace_id: params.trace_id,
+                limit: params.limit,
+                offset: params.offset,
+                ..Default::default()
+            })
+        },
+        "failed to query feed",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(msgs)) => {
-            let msgs: Vec<Message> = msgs
-                .into_iter()
-                .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
-                .collect();
-            response::ok(msgs).into_response()
-        }
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to query feed",
-        )
-        .into_response(),
-    }
+    let msgs: Vec<Message> = msgs
+        .into_iter()
+        .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
+        .collect();
+    response::ok(msgs).into_response()
 }
 
 pub async fn get_insights(
@@ -130,33 +124,29 @@ pub async fn get_insights(
     let engine = state.engine.clone();
     let identity = state.identity.clone();
 
-    let result = tokio::task::spawn_blocking(move || {
-        engine.query(&FeedQuery {
-            content_type: Some("insight".to_string()),
-            trace_id: params.trace_id,
-            limit: params.limit,
-            offset: params.offset,
-            ..Default::default()
-        })
-    })
-    .await;
+    let msgs = match response::run_blocking(
+        move || {
+            engine.query(&FeedQuery {
+                content_type: Some("insight".to_string()),
+                trace_id: params.trace_id,
+                limit: params.limit,
+                offset: params.offset,
+                ..Default::default()
+            })
+        },
+        "failed to query insights",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(msgs)) => {
-            let msgs: Vec<Message> = msgs
-                .into_iter()
-                .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
-                .collect();
-            response::ok(msgs).into_response()
-        }
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to query insights",
-        )
-        .into_response(),
-    }
+    let msgs: Vec<Message> = msgs
+        .into_iter()
+        .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
+        .collect();
+    response::ok(msgs).into_response()
 }
 
 pub async fn search_insights(
@@ -177,24 +167,21 @@ pub async fn search_insights(
         .into_response();
     }
 
-    let result = tokio::task::spawn_blocking(move || engine.search(&query_text, limit)).await;
+    let msgs = match response::run_blocking(
+        move || engine.search(&query_text, limit),
+        "failed to search insights",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(msgs)) => {
-            let msgs: Vec<Message> = msgs
-                .into_iter()
-                .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
-                .collect();
-            response::ok(msgs).into_response()
-        }
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to search insights",
-        )
-        .into_response(),
-    }
+    let msgs: Vec<Message> = msgs
+        .into_iter()
+        .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
+        .collect();
+    response::ok(msgs).into_response()
 }
 
 pub async fn get_message_by_hash(
@@ -204,23 +191,25 @@ pub async fn get_message_by_hash(
     let engine = state.engine.clone();
     let identity = state.identity.clone();
 
-    let result = tokio::task::spawn_blocking(move || engine.get_message(&hash)).await;
+    let msg = match response::run_blocking(
+        move || engine.get_message(&hash),
+        "failed to retrieve message",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(Some(msg))) => {
-            response::ok(crate::feed::private_box::decrypt_or_passthrough(&identity, msg)).into_response()
+    match msg {
+        Some(msg) => {
+            response::ok(crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
+                .into_response()
         }
-        Ok(Ok(None)) => response::err::<()>(
+        None => response::err::<()>(
             axum::http::StatusCode::NOT_FOUND,
             "NOT_FOUND",
             "message not found",
-        )
-        .into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to retrieve message",
         )
         .into_response(),
     }

--- a/src/api/routes_feed.rs
+++ b/src/api/routes_feed.rs
@@ -15,7 +15,6 @@ use crate::api::response;
 use crate::api::AppState;
 use crate::feed::models::FeedQuery;
 use crate::feed::models::Message;
-use crate::feed::private_box;
 use crate::identity::PublicId;
 
 #[derive(Deserialize, Default)]
@@ -67,7 +66,7 @@ pub async fn get_feed(
         Ok(Ok(msgs)) => {
             let msgs: Vec<Message> = msgs
                 .into_iter()
-                .map(|msg| decrypt_for_local_identity(&identity, msg))
+                .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
                 .collect();
             let meta = response::ApiMetadata {
                 total: None,
@@ -110,7 +109,7 @@ pub async fn get_feed_by_author(
         Ok(Ok(msgs)) => {
             let msgs: Vec<Message> = msgs
                 .into_iter()
-                .map(|msg| decrypt_for_local_identity(&identity, msg))
+                .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
                 .collect();
             response::ok(msgs).into_response()
         }
@@ -146,7 +145,7 @@ pub async fn get_insights(
         Ok(Ok(msgs)) => {
             let msgs: Vec<Message> = msgs
                 .into_iter()
-                .map(|msg| decrypt_for_local_identity(&identity, msg))
+                .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
                 .collect();
             response::ok(msgs).into_response()
         }
@@ -184,7 +183,7 @@ pub async fn search_insights(
         Ok(Ok(msgs)) => {
             let msgs: Vec<Message> = msgs
                 .into_iter()
-                .map(|msg| decrypt_for_local_identity(&identity, msg))
+                .map(|msg| crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
                 .collect();
             response::ok(msgs).into_response()
         }
@@ -209,7 +208,7 @@ pub async fn get_message_by_hash(
 
     match result {
         Ok(Ok(Some(msg))) => {
-            response::ok(decrypt_for_local_identity(&identity, msg)).into_response()
+            response::ok(crate::feed::private_box::decrypt_or_passthrough(&identity, msg)).into_response()
         }
         Ok(Ok(None)) => response::err::<()>(
             axum::http::StatusCode::NOT_FOUND,
@@ -227,17 +226,3 @@ pub async fn get_message_by_hash(
     }
 }
 
-fn decrypt_for_local_identity(identity: &crate::identity::Identity, message: Message) -> Message {
-    if !private_box::is_private_box_content(&message.content) {
-        return message;
-    }
-
-    match private_box::decrypt_for_identity(identity, &message) {
-        Ok(Some(decrypted)) => decrypted,
-        Ok(None) => message,
-        Err(error) => {
-            tracing::warn!(error = %error, hash = %message.hash, "failed to decrypt private box message");
-            message
-        }
-    }
-}

--- a/src/api/routes_feed.rs
+++ b/src/api/routes_feed.rs
@@ -202,10 +202,10 @@ pub async fn get_message_by_hash(
     };
 
     match msg {
-        Some(msg) => {
-            response::ok(crate::feed::private_box::decrypt_or_passthrough(&identity, msg))
-                .into_response()
-        }
+        Some(msg) => response::ok(crate::feed::private_box::decrypt_or_passthrough(
+            &identity, msg,
+        ))
+        .into_response(),
         None => response::err::<()>(
             axum::http::StatusCode::NOT_FOUND,
             "NOT_FOUND",
@@ -214,4 +214,3 @@ pub async fn get_message_by_hash(
         .into_response(),
     }
 }
-

--- a/src/api/routes_follows.rs
+++ b/src/api/routes_follows.rs
@@ -27,18 +27,16 @@ pub async fn add_follow(
     let engine = state.engine.clone();
     let author_id = PublicId(author.clone());
 
-    let result = tokio::task::spawn_blocking(move || engine.store().add_follow(&author_id)).await;
-
-    match result {
-        Ok(Ok(())) => (StatusCode::CREATED, response::ok(FollowInfo { author })).into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to add follow",
-        )
-        .into_response(),
+    if let Err(resp) = response::run_blocking(
+        move || engine.store().add_follow(&author_id),
+        "failed to add follow",
+    )
+    .await
+    {
+        return resp;
     }
+
+    (StatusCode::CREATED, response::ok(FollowInfo { author })).into_response()
 }
 
 pub async fn remove_follow(
@@ -56,40 +54,34 @@ pub async fn remove_follow(
     let engine = state.engine.clone();
     let author_id = PublicId(author);
 
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().remove_follow(&author_id)).await;
-
-    match result {
-        Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to remove follow",
-        )
-        .into_response(),
+    if let Err(resp) = response::run_blocking(
+        move || engine.store().remove_follow(&author_id),
+        "failed to remove follow",
+    )
+    .await
+    {
+        return resp;
     }
+
+    StatusCode::NO_CONTENT.into_response()
 }
 
 pub async fn get_follows(State(state): State<AppState>) -> impl IntoResponse {
     let engine = state.engine.clone();
 
-    let result = tokio::task::spawn_blocking(move || engine.store().get_follows()).await;
+    let follows = match response::run_blocking(
+        move || engine.store().get_follows(),
+        "failed to list follows",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(follows)) => {
-            let infos: Vec<FollowInfo> = follows
-                .into_iter()
-                .map(|pid| FollowInfo { author: pid.0 })
-                .collect();
-            response::ok(infos).into_response()
-        }
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to list follows",
-        )
-        .into_response(),
-    }
+    let infos: Vec<FollowInfo> = follows
+        .into_iter()
+        .map(|pid| FollowInfo { author: pid.0 })
+        .collect();
+    response::ok(infos).into_response()
 }

--- a/src/api/routes_peers.rs
+++ b/src/api/routes_peers.rs
@@ -157,27 +157,24 @@ pub async fn add_peer(
     let address = req.address.clone();
     let engine = state.engine.clone();
 
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().insert_address_peer(&address)).await;
-
-    match result {
-        Ok(Ok(())) => (
-            StatusCode::CREATED,
-            response::ok(PeerInfo {
-                address: req.address,
-                public_id: None,
-                source: "manual".to_string(),
-            }),
-        )
-            .into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<PeerInfo>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to persist peer",
-        )
-        .into_response(),
+    if let Err(resp) = response::run_blocking(
+        move || engine.store().insert_address_peer(&address),
+        "failed to persist peer",
+    )
+    .await
+    {
+        return resp;
     }
+
+    (
+        StatusCode::CREATED,
+        response::ok(PeerInfo {
+            address: req.address,
+            public_id: None,
+            source: "manual".to_string(),
+        }),
+    )
+        .into_response()
 }
 
 pub async fn delete_peer(
@@ -196,19 +193,16 @@ pub async fn delete_peer(
 
     let engine = state.engine.clone();
 
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().remove_address_peer(&address)).await;
-
-    match result {
-        Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to remove peer",
-        )
-        .into_response(),
+    if let Err(resp) = response::run_blocking(
+        move || engine.store().remove_address_peer(&address),
+        "failed to remove peer",
+    )
+    .await
+    {
+        return resp;
     }
+
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// Build status info from current state. Shared by HTTP route and MCP tool.

--- a/src/api/routes_retention.rs
+++ b/src/api/routes_retention.rs
@@ -124,23 +124,18 @@ impl From<RetentionPolicy> for PolicyResponse {
 pub async fn list_policies(State(state): State<AppState>) -> impl IntoResponse {
     let engine = state.engine.clone();
 
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().list_retention_policies()).await;
+    let policies = match response::run_blocking(
+        move || engine.store().list_retention_policies(),
+        "failed to list retention policies",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(policies)) => {
-            let responses: Vec<PolicyResponse> =
-                policies.into_iter().map(PolicyResponse::from).collect();
-            response::ok(responses).into_response()
-        }
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to list retention policies",
-        )
-        .into_response(),
-    }
+    let responses: Vec<PolicyResponse> = policies.into_iter().map(PolicyResponse::from).collect();
+    response::ok(responses).into_response()
 }
 
 /// Create a retention policy.
@@ -238,24 +233,19 @@ pub async fn create_policy(
 
     let engine = state.engine.clone();
     let policy_clone = policy.clone();
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().save_retention_policy(&policy_clone))
-            .await;
+    let id = match response::run_blocking(
+        move || engine.store().save_retention_policy(&policy_clone),
+        "failed to create retention policy",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(id)) => {
-            let mut resp = PolicyResponse::from(policy);
-            resp.id = id;
-            (StatusCode::CREATED, response::ok(resp)).into_response()
-        }
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to create retention policy",
-        )
-        .into_response(),
-    }
+    let mut resp = PolicyResponse::from(policy);
+    resp.id = id;
+    (StatusCode::CREATED, response::ok(resp)).into_response()
 }
 
 /// Delete a retention policy by ID.
@@ -265,23 +255,24 @@ pub async fn delete_policy(
 ) -> impl IntoResponse {
     let engine = state.engine.clone();
 
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().delete_retention_policy(id)).await;
+    let deleted = match response::run_blocking(
+        move || engine.store().delete_retention_policy(id),
+        "failed to delete retention policy",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(true)) => StatusCode::NO_CONTENT.into_response(),
-        Ok(Ok(false)) => response::err::<()>(
+    if deleted {
+        StatusCode::NO_CONTENT.into_response()
+    } else {
+        response::err::<()>(
             StatusCode::NOT_FOUND,
             "NOT_FOUND",
             "retention policy not found",
         )
-        .into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to delete retention policy",
-        )
-        .into_response(),
+        .into_response()
     }
 }

--- a/src/api/routes_topics.rs
+++ b/src/api/routes_topics.rs
@@ -44,26 +44,22 @@ pub async fn add_topic_subscription(
     let engine = state.engine.clone();
     let topic_owned = trimmed.to_string();
 
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().add_topic_subscription(&topic_owned))
-            .await;
-
-    match result {
-        Ok(Ok(())) => (
-            StatusCode::CREATED,
-            response::ok(TopicInfo {
-                topic: trimmed.to_string(),
-            }),
-        )
-            .into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to add topic subscription",
-        )
-        .into_response(),
+    if let Err(resp) = response::run_blocking(
+        move || engine.store().add_topic_subscription(&topic_owned),
+        "failed to add topic subscription",
+    )
+    .await
+    {
+        return resp;
     }
+
+    (
+        StatusCode::CREATED,
+        response::ok(TopicInfo {
+            topic: trimmed.to_string(),
+        }),
+    )
+        .into_response()
 }
 
 /// Unsubscribe from a topic.
@@ -85,78 +81,69 @@ pub async fn remove_topic_subscription(
     let engine = state.engine.clone();
     let topic_owned = trimmed.to_string();
 
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().remove_topic_subscription(&topic_owned))
-            .await;
-
-    match result {
-        Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to remove topic subscription",
-        )
-        .into_response(),
+    if let Err(resp) = response::run_blocking(
+        move || engine.store().remove_topic_subscription(&topic_owned),
+        "failed to remove topic subscription",
+    )
+    .await
+    {
+        return resp;
     }
+
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// List all topic subscriptions.
 pub async fn get_topic_subscriptions(State(state): State<AppState>) -> impl IntoResponse {
     let engine = state.engine.clone();
 
-    let result =
-        tokio::task::spawn_blocking(move || engine.store().get_topic_subscriptions()).await;
+    let topics = match response::run_blocking(
+        move || engine.store().get_topic_subscriptions(),
+        "failed to list topic subscriptions",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(topics)) => {
-            let infos: Vec<TopicInfo> = topics
-                .into_iter()
-                .map(|topic| TopicInfo { topic })
-                .collect();
-            response::ok(infos).into_response()
-        }
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to list topic subscriptions",
-        )
-        .into_response(),
-    }
+    let infos: Vec<TopicInfo> = topics
+        .into_iter()
+        .map(|topic| TopicInfo { topic })
+        .collect();
+    response::ok(infos).into_response()
 }
 
 /// List all known topics (discovered from messages) with subscription status.
 pub async fn get_known_topics(State(state): State<AppState>) -> impl IntoResponse {
     let engine = state.engine.clone();
 
-    let result = tokio::task::spawn_blocking(move || {
-        let store = engine.store();
-        let known = store.get_all_known_topics()?;
-        let subscribed = store.get_topic_subscriptions()?;
-        let subscribed_set: std::collections::HashSet<String> = subscribed.into_iter().collect();
+    let infos = match response::run_blocking(
+        move || {
+            let store = engine.store();
+            let known = store.get_all_known_topics()?;
+            let subscribed = store.get_topic_subscriptions()?;
+            let subscribed_set: std::collections::HashSet<String> =
+                subscribed.into_iter().collect();
 
-        let infos: Vec<KnownTopicInfo> = known
-            .into_iter()
-            .map(|topic| KnownTopicInfo {
-                subscribed: subscribed_set.contains(&topic),
-                topic,
-            })
-            .collect();
-        Ok::<_, crate::error::EgreError>(infos)
-    })
-    .await;
+            let infos: Vec<KnownTopicInfo> = known
+                .into_iter()
+                .map(|topic| KnownTopicInfo {
+                    subscribed: subscribed_set.contains(&topic),
+                    topic,
+                })
+                .collect();
+            Ok::<_, crate::error::EgreError>(infos)
+        },
+        "failed to list known topics",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
-    match result {
-        Ok(Ok(infos)) => response::ok(infos).into_response(),
-        Ok(Err(e)) => response::from_error(e),
-        Err(_) => response::err::<()>(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            "failed to list known topics",
-        )
-        .into_response(),
-    }
+    response::ok(infos).into_response()
 }
 
 #[cfg(test)]

--- a/src/feed/private_box.rs
+++ b/src/feed/private_box.rs
@@ -79,6 +79,30 @@ pub fn decrypt_for_identity(identity: &Identity, message: &Message) -> Result<Op
     Ok(Some(decrypted))
 }
 
+/// Decrypt `message` if it carries a private-box payload addressed to
+/// `identity`; otherwise return the message unchanged. Decryption failures
+/// (envelope-shaped but unrecoverable) are logged and surfaced as the
+/// original ciphertext message — we never drop the message, so callers
+/// always get something to render.
+pub fn decrypt_or_passthrough(identity: &Identity, message: Message) -> Message {
+    if !is_private_box_content(&message.content) {
+        return message;
+    }
+
+    match decrypt_for_identity(identity, &message) {
+        Ok(Some(decrypted)) => decrypted,
+        Ok(None) => message,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                hash = %message.hash,
+                "failed to decrypt private box message",
+            );
+            message
+        }
+    }
+}
+
 pub fn is_private_box_content(content: &serde_json::Value) -> bool {
     content
         .get("type")

--- a/src/feed/store/messages.rs
+++ b/src/feed/store/messages.rs
@@ -5,13 +5,80 @@
 //! Backfill promotes the flag when the missing predecessor arrives.
 
 use chrono::{DateTime, Utc};
-use rusqlite::{params, OptionalExtension, TransactionBehavior};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 
 use crate::error::{EgreError, Result};
 use crate::feed::models::{FeedQuery, Message};
 use crate::identity::PublicId;
 
 use super::{content_type_name, FeedStore};
+
+/// Shared persistence block for both the publish (atomic, transactional) and
+/// ingest (plain connection) paths. Inserts the message row, its tags, and
+/// updates the feed-tracking row.
+///
+/// Takes `&rusqlite::Connection`; `rusqlite::Transaction` derefs to it, so
+/// callers in either context (transactional or not) pass through. The
+/// transaction boundary stays at the caller — this helper does NOT begin or
+/// commit, and is NOT atomic across the three table writes when invoked
+/// outside a transaction (matches the prior `insert_message` semantics).
+///
+/// `ConstraintViolation` is mapped to `EgreError::DuplicateMessage` ONLY for
+/// the `messages` insert (the row that carries the duplicate-detection
+/// invariants — `PRIMARY KEY(hash)` and `UNIQUE(author, sequence)`). Failures
+/// on `message_tags` / `feeds` surface as raw `EgreError::Database`.
+fn insert_message_row(conn: &Connection, msg: &Message, chain_valid: bool) -> Result<()> {
+    let content_type = content_type_name(&msg.content);
+    let content_json = serde_json::to_string(&msg.content)?;
+    let raw_json = serde_json::to_string(msg)?;
+
+    conn.execute(
+        "INSERT INTO messages (hash, author, sequence, previous, timestamp, content_type, content_json, signature, raw_json, chain_valid, relates)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        params![
+            msg.hash,
+            msg.author.0,
+            msg.sequence,
+            msg.previous,
+            msg.timestamp.to_rfc3339(),
+            content_type,
+            content_json,
+            msg.signature,
+            raw_json,
+            chain_valid as i32,
+            msg.relates,
+        ],
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::SqliteFailure(err, _)
+            if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+        {
+            EgreError::DuplicateMessage {
+                author: msg.author.0.clone(),
+                sequence: msg.sequence,
+            }
+        }
+        other => EgreError::Database(other),
+    })?;
+
+    for tag in &msg.tags {
+        conn.execute(
+            "INSERT OR IGNORE INTO message_tags (message_hash, tag) VALUES (?1, ?2)",
+            params![msg.hash, tag],
+        )?;
+    }
+
+    conn.execute(
+        "INSERT INTO feeds (author, latest_sequence, last_seen)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(author) DO UPDATE SET
+            latest_sequence = MAX(feeds.latest_sequence, excluded.latest_sequence),
+            last_seen = excluded.last_seen",
+        params![msg.author.0, msg.sequence, msg.timestamp.to_rfc3339()],
+    )?;
+
+    Ok(())
+}
 
 /// Phase 2 Wave 5 Step 27 (amendment §G.3) — per-author summary of
 /// chain-gap state for the Prometheus metrics updater. One row per
@@ -74,64 +141,12 @@ impl FeedStore {
             None
         };
 
-        // Build the message (computes hash, signs)
+        // Build the message (computes hash, signs).
         let message = builder(new_seq, previous)?;
 
-        // Insert within same transaction
-        let content_type = content_type_name(&message.content);
-        let content_json = serde_json::to_string(&message.content)?;
-        let raw_json = serde_json::to_string(&message)?;
-
-        tx.execute(
-            "INSERT INTO messages (hash, author, sequence, previous, timestamp, content_type, content_json, signature, raw_json, chain_valid, relates)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-            params![
-                message.hash,
-                message.author.0,
-                message.sequence,
-                message.previous,
-                message.timestamp.to_rfc3339(),
-                content_type,
-                content_json,
-                message.signature,
-                raw_json,
-                1i32, // chain_valid = true for locally published messages
-                message.relates,
-            ],
-        )
-        .map_err(|e| match e {
-            rusqlite::Error::SqliteFailure(err, _)
-                if err.code == rusqlite::ErrorCode::ConstraintViolation =>
-            {
-                EgreError::DuplicateMessage {
-                    author: message.author.0.clone(),
-                    sequence: message.sequence,
-                }
-            }
-            other => EgreError::Database(other),
-        })?;
-
-        // Insert tags
-        for tag in &message.tags {
-            tx.execute(
-                "INSERT OR IGNORE INTO message_tags (message_hash, tag) VALUES (?1, ?2)",
-                params![message.hash, tag],
-            )?;
-        }
-
-        // Update feed tracking
-        tx.execute(
-            "INSERT INTO feeds (author, latest_sequence, last_seen)
-             VALUES (?1, ?2, ?3)
-             ON CONFLICT(author) DO UPDATE SET
-                latest_sequence = MAX(feeds.latest_sequence, excluded.latest_sequence),
-                last_seen = excluded.last_seen",
-            params![
-                message.author.0,
-                message.sequence,
-                message.timestamp.to_rfc3339(),
-            ],
-        )?;
+        // Persist within the same transaction. chain_valid = true for locally
+        // published messages (we just signed and know the predecessor exists).
+        insert_message_row(&tx, &message, true)?;
 
         tx.commit()?;
         Ok(message)
@@ -140,59 +155,7 @@ impl FeedStore {
     /// Insert a message. `chain_valid` indicates whether the hash chain
     /// linkage to the predecessor has been verified.
     pub fn insert_message(&self, msg: &Message, chain_valid: bool) -> Result<()> {
-        let conn = self.conn();
-        let content_type = content_type_name(&msg.content);
-        let content_json = serde_json::to_string(&msg.content)?;
-        let raw_json = serde_json::to_string(msg)?;
-
-        conn.execute(
-            "INSERT INTO messages (hash, author, sequence, previous, timestamp, content_type, content_json, signature, raw_json, chain_valid, relates)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-            params![
-                msg.hash,
-                msg.author.0,
-                msg.sequence,
-                msg.previous,
-                msg.timestamp.to_rfc3339(),
-                content_type,
-                content_json,
-                msg.signature,
-                raw_json,
-                chain_valid as i32,
-                msg.relates,
-            ],
-        )
-        .map_err(|e| match e {
-            rusqlite::Error::SqliteFailure(err, _)
-                if err.code == rusqlite::ErrorCode::ConstraintViolation =>
-            {
-                EgreError::DuplicateMessage {
-                    author: msg.author.0.clone(),
-                    sequence: msg.sequence,
-                }
-            }
-            other => EgreError::Database(other),
-        })?;
-
-        // Insert tags
-        for tag in &msg.tags {
-            conn.execute(
-                "INSERT OR IGNORE INTO message_tags (message_hash, tag) VALUES (?1, ?2)",
-                params![msg.hash, tag],
-            )?;
-        }
-
-        // Update feed tracking
-        conn.execute(
-            "INSERT INTO feeds (author, latest_sequence, last_seen)
-             VALUES (?1, ?2, ?3)
-             ON CONFLICT(author) DO UPDATE SET
-                latest_sequence = MAX(feeds.latest_sequence, excluded.latest_sequence),
-                last_seen = excluded.last_seen",
-            params![msg.author.0, msg.sequence, msg.timestamp.to_rfc3339(),],
-        )?;
-
-        Ok(())
+        insert_message_row(&self.conn(), msg, chain_valid)
     }
 
     /// Update the chain_valid flag for a message identified by hash.

--- a/src/main.rs
+++ b/src/main.rs
@@ -911,11 +911,11 @@ async fn main() -> anyhow::Result<()> {
     use egregore::transport::composite::transport::{ChildSpec, CompositeTransport};
     let mut child_specs: Vec<ChildSpec> = Vec::new();
     if let Some(gossip) = gossip_transport.as_ref() {
-        child_specs.push(ChildSpec::gossip(gossip.clone()));
+        child_specs.push(ChildSpec::new(gossip.clone()));
     }
     if let Some(bus_arc) = bus_transport_arc.as_ref() {
         let bus_as_trait: Arc<dyn egregore::transport::Transport> = bus_arc.clone();
-        child_specs.push(ChildSpec::bus(bus_as_trait, bus_arc.clone()));
+        child_specs.push(ChildSpec::new(bus_as_trait));
     }
     let effective_transport: Option<Arc<dyn egregore::transport::Transport>> =
         match child_specs.len() {

--- a/src/transport/bus/transport.rs
+++ b/src/transport/bus/transport.rs
@@ -765,6 +765,20 @@ impl Transport for BusTransport {
             bridge_queues: None,
         }
     }
+
+    /// Override the trait default to drain `pending_acks` on broker-side
+    /// resolution. Composite egress calls this on the source bus child once
+    /// every destination has been published (RFC 0002 §C.5).
+    async fn ack_after_publish(&self, message_hash: &str) -> Result<()> {
+        BusTransport::ack_after_publish(self, message_hash).await
+    }
+
+    /// Override the trait default to expose the canonical self-echo counter
+    /// (amendment §C.4 retcon). Composite health aggregation reads this for
+    /// bus children; gossip and other non-bus children keep the default 0.
+    fn self_echo_total(&self) -> u64 {
+        BusTransport::self_echo_total(self)
+    }
 }
 
 #[cfg(test)]

--- a/src/transport/composite/egress.rs
+++ b/src/transport/composite/egress.rs
@@ -17,7 +17,6 @@ use std::time::Instant;
 use dashmap::DashMap;
 use tokio_util::sync::CancellationToken;
 
-use crate::transport::bus::BusTransport;
 use crate::transport::trait_def::Transport;
 
 use super::direction::{AckBarrier, DirectionState, TransportId};
@@ -34,7 +33,7 @@ pub(crate) async fn run_egress(
     dest_transport: Arc<dyn Transport>,
     dir: Arc<DirectionState>,
     ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>>,
-    bus_children: Arc<Vec<Option<Arc<BusTransport>>>>,
+    children: Arc<Vec<Arc<dyn Transport>>>,
     cancel: CancellationToken,
 ) {
     let mut rr_cursor: usize = 0;
@@ -162,8 +161,12 @@ pub(crate) async fn run_egress(
                 );
             }
 
-            if let Some(Some(bus)) = bus_children.get(source_id) {
-                if let Err(e) = bus.ack_after_publish(&msg.hash).await {
+            if let Some(source) = children.get(source_id) {
+                // Bus children override ack_after_publish to drain
+                // pending_acks; gossip and other non-bus children keep
+                // the trait's default no-op (Ok(())). Barrier removal
+                // above completes the cycle either way.
+                if let Err(e) = source.ack_after_publish(&msg.hash).await {
                     tracing::warn!(
                         source_id,
                         error = %e,
@@ -172,8 +175,6 @@ pub(crate) async fn run_egress(
                     *dir.last_error.write() = Some("source ack_after_publish error".to_string());
                 }
             }
-            // Gossip-sourced: source_id's bus_children slot is None —
-            // nothing to ack. Barrier removal above completes the cycle.
         }
     }
 }
@@ -210,6 +211,114 @@ mod tests {
             expires_at: None,
             hash: format!("hash-{author}-{seq}"),
             signature: "sig".to_string(),
+        }
+    }
+
+    /// Minimal stub that satisfies the `Transport` trait via defaults.
+    /// Used to populate the `children` parameter of `run_egress` for tests
+    /// that don't exercise source-side ack semantics — gossip-equivalent
+    /// behavior (the trait's default `ack_after_publish` returns `Ok(())`).
+    struct StubChild;
+
+    #[async_trait]
+    impl Transport for StubChild {
+        async fn publish(&self, _msg: &Message) -> Result<()> {
+            Ok(())
+        }
+        async fn subscribe(
+            &self,
+            _f: TopicFilter,
+        ) -> Result<(SubscriptionHandle, BoxStream<'static, Message>)> {
+            unreachable!("StubChild is ack-only")
+        }
+        async fn request_from(&self, _a: PublicId, _s: u64) -> Result<BoxStream<'static, Message>> {
+            unreachable!()
+        }
+        async fn start(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn shutdown(&self, _d: Duration) -> Result<()> {
+            Ok(())
+        }
+        fn health(&self) -> TransportHealth {
+            TransportHealth {
+                connected: true,
+                backend: "stub",
+                last_successful_publish: None,
+                last_peer_contact: None,
+                unreplicated_count: 0,
+                inflight_publishes: 0,
+                last_error: None,
+                children: vec![],
+                bridge_queues: None,
+            }
+        }
+    }
+
+    fn stub_children(n: usize) -> Arc<Vec<Arc<dyn Transport>>> {
+        Arc::new(
+            (0..n)
+                .map(|_| Arc::new(StubChild) as Arc<dyn Transport>)
+                .collect(),
+        )
+    }
+
+    /// A source-side mock that records `ack_after_publish` invocations.
+    /// Used to assert that egress dispatches the source-ack call through
+    /// the `Transport` trait (i.e. that BusTransport's override would fire,
+    /// without needing a live NATS connection to construct a real bus).
+    struct RecordingSource {
+        ack_calls: Arc<PlMutex<Vec<String>>>,
+    }
+
+    impl RecordingSource {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                ack_calls: Arc::new(PlMutex::new(Vec::new())),
+            })
+        }
+
+        fn ack_calls(&self) -> Vec<String> {
+            self.ack_calls.lock().clone()
+        }
+    }
+
+    #[async_trait]
+    impl Transport for RecordingSource {
+        async fn publish(&self, _msg: &Message) -> Result<()> {
+            Ok(())
+        }
+        async fn subscribe(
+            &self,
+            _f: TopicFilter,
+        ) -> Result<(SubscriptionHandle, BoxStream<'static, Message>)> {
+            unreachable!("RecordingSource is ack-only")
+        }
+        async fn request_from(&self, _a: PublicId, _s: u64) -> Result<BoxStream<'static, Message>> {
+            unreachable!()
+        }
+        async fn start(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn shutdown(&self, _d: Duration) -> Result<()> {
+            Ok(())
+        }
+        fn health(&self) -> TransportHealth {
+            TransportHealth {
+                connected: true,
+                backend: "recording",
+                last_successful_publish: None,
+                last_peer_contact: None,
+                unreplicated_count: 0,
+                inflight_publishes: 0,
+                last_error: None,
+                children: vec![],
+                bridge_queues: None,
+            }
+        }
+        async fn ack_after_publish(&self, message_hash: &str) -> Result<()> {
+            self.ack_calls.lock().push(message_hash.to_string());
+            Ok(())
         }
     }
 
@@ -296,7 +405,7 @@ mod tests {
         let dir = Arc::new(DirectionState::new());
         let dest = MockDest::new();
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None]);
+        let children = stub_children(2);
         let cancel = CancellationToken::new();
 
         // Pre-enqueue 3 messages from source_id=0 to this destination.
@@ -309,7 +418,7 @@ mod tests {
         let dir_clone = dir.clone();
         let dest_clone = dest.clone();
         let barriers_clone = ack_barriers.clone();
-        let bus_children_clone = bus_children.clone();
+        let children_clone = children.clone();
         let cancel_clone = cancel.clone();
         let egress = tokio::spawn(async move {
             run_egress(
@@ -317,7 +426,7 @@ mod tests {
                 dest_clone as Arc<dyn Transport>,
                 dir_clone,
                 barriers_clone,
-                bus_children_clone,
+                children_clone,
                 cancel_clone,
             )
             .await;
@@ -344,7 +453,7 @@ mod tests {
         let dir = Arc::new(DirectionState::new());
         let dest = MockDest::new();
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None]);
+        let children = stub_children(2);
         let cancel = CancellationToken::new();
 
         // Two authors from the same source, 3 messages each. Interleaved
@@ -360,7 +469,7 @@ mod tests {
         let dir_clone = dir.clone();
         let dest_clone = dest.clone();
         let barriers_clone = ack_barriers.clone();
-        let bus_children_clone = bus_children.clone();
+        let children_clone = children.clone();
         let cancel_clone = cancel.clone();
         let egress = tokio::spawn(async move {
             run_egress(
@@ -368,7 +477,7 @@ mod tests {
                 dest_clone as Arc<dyn Transport>,
                 dir_clone,
                 barriers_clone,
-                bus_children_clone,
+                children_clone,
                 cancel_clone,
             )
             .await;
@@ -405,7 +514,7 @@ mod tests {
         let dir = Arc::new(DirectionState::new());
         let dest = MockDest::new();
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None]);
+        let children = stub_children(2);
         let cancel = CancellationToken::new();
 
         let author = "@a.ed25519";
@@ -439,7 +548,7 @@ mod tests {
         let dir_clone = dir.clone();
         let dest_clone = dest.clone();
         let barriers_clone = ack_barriers.clone();
-        let bus_children_clone = bus_children.clone();
+        let children_clone = children.clone();
         let cancel_clone = cancel.clone();
         let egress = tokio::spawn(async move {
             run_egress(
@@ -447,7 +556,7 @@ mod tests {
                 dest_clone as Arc<dyn Transport>,
                 dir_clone,
                 barriers_clone,
-                bus_children_clone,
+                children_clone,
                 cancel_clone,
             )
             .await;
@@ -483,7 +592,7 @@ mod tests {
         // removal. The bus-specific ack call is exercised in the
         // integration smoke test (Step 13).
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None, None]);
+        let children = stub_children(3);
         let cancel = CancellationToken::new();
 
         let msg = sample_message("@a.ed25519", 1);
@@ -494,7 +603,7 @@ mod tests {
         let dir_clone = dir.clone();
         let dest_clone = dest.clone();
         let barriers_clone = ack_barriers.clone();
-        let bus_children_clone = bus_children.clone();
+        let children_clone = children.clone();
         let cancel_clone = cancel.clone();
         let egress = tokio::spawn(async move {
             run_egress(
@@ -502,7 +611,7 @@ mod tests {
                 dest_clone as Arc<dyn Transport>,
                 dir_clone,
                 barriers_clone,
-                bus_children_clone,
+                children_clone,
                 cancel_clone,
             )
             .await;
@@ -542,7 +651,7 @@ mod tests {
             reason: "simulated destination failure".to_string(),
         }));
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None]);
+        let children = stub_children(2);
         let cancel = CancellationToken::new();
 
         let msg = sample_message("@a.ed25519", 1);
@@ -552,7 +661,7 @@ mod tests {
         let dir_clone = dir.clone();
         let dest_clone = dest.clone();
         let barriers_clone = ack_barriers.clone();
-        let bus_children_clone = bus_children.clone();
+        let children_clone = children.clone();
         let cancel_clone = cancel.clone();
         let egress = tokio::spawn(async move {
             run_egress(
@@ -560,7 +669,7 @@ mod tests {
                 dest_clone as Arc<dyn Transport>,
                 dir_clone,
                 barriers_clone,
-                bus_children_clone,
+                children_clone,
                 cancel_clone,
             )
             .await;
@@ -590,13 +699,13 @@ mod tests {
         let dir = Arc::new(DirectionState::new());
         let dest = MockDest::new();
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None]);
+        let children = stub_children(2);
         let cancel = CancellationToken::new();
 
         let dir_clone = dir.clone();
         let dest_clone = dest.clone();
         let barriers_clone = ack_barriers.clone();
-        let bus_children_clone = bus_children.clone();
+        let children_clone = children.clone();
         let cancel_clone = cancel.clone();
         let egress = tokio::spawn(async move {
             run_egress(
@@ -604,7 +713,7 @@ mod tests {
                 dest_clone as Arc<dyn Transport>,
                 dir_clone,
                 barriers_clone,
-                bus_children_clone,
+                children_clone,
                 cancel_clone,
             )
             .await;
@@ -632,14 +741,14 @@ mod tests {
         let dir = Arc::new(DirectionState::new());
         let dest = MockDest::new();
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None]);
+        let children = stub_children(2);
         let cancel = CancellationToken::new();
 
         let egress = tokio::spawn({
             let dir = dir.clone();
             let dest = dest.clone();
             let ack_barriers = ack_barriers.clone();
-            let bus_children = bus_children.clone();
+            let children_inner = children.clone();
             let cancel = cancel.clone();
             async move {
                 run_egress(
@@ -647,7 +756,7 @@ mod tests {
                     dest as Arc<dyn Transport>,
                     dir,
                     ack_barriers,
-                    bus_children,
+                    children_inner,
                     cancel,
                 )
                 .await;
@@ -662,12 +771,70 @@ mod tests {
         );
     }
 
+    /// Locks the trait-dispatch contract for the source-side ack hook
+    /// without requiring a live NATS connection. After the C3 refactor,
+    /// `run_egress` calls `source.ack_after_publish(hash)` via the
+    /// `Transport` trait — `BusTransport` overrides the default no-op to
+    /// drain `pending_acks`. This test substitutes a `RecordingSource`
+    /// (also overrides) at index 0 and asserts the override fires when the
+    /// barrier resolves to zero.
+    #[tokio::test]
+    async fn egress_dispatches_ack_after_publish_through_trait() {
+        let dir = Arc::new(DirectionState::new());
+        let dest = MockDest::new();
+        let recording = RecordingSource::new();
+        let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
+        // children[0] = RecordingSource (the source we'll receive an ack on);
+        // children[1] is a stub that we don't exercise.
+        let children: Arc<Vec<Arc<dyn Transport>>> = Arc::new(vec![
+            recording.clone() as Arc<dyn Transport>,
+            Arc::new(StubChild) as Arc<dyn Transport>,
+        ]);
+        let cancel = CancellationToken::new();
+
+        let msg = sample_message("@a.ed25519", 1);
+        let hash = msg.hash.clone();
+        // Single destination → barrier resolves to zero on the first publish.
+        ack_barriers.insert(hash.clone(), Arc::new(AckBarrier::new(0, 1)));
+        pre_enqueue(&dir, 0, msg);
+
+        let dir_clone = dir.clone();
+        let dest_clone = dest.clone();
+        let barriers_clone = ack_barriers.clone();
+        let children_clone = children.clone();
+        let cancel_clone = cancel.clone();
+        let egress = tokio::spawn(async move {
+            run_egress(
+                1,
+                dest_clone as Arc<dyn Transport>,
+                dir_clone,
+                barriers_clone,
+                children_clone,
+                cancel_clone,
+            )
+            .await;
+        });
+        dir.egress_wake.notify_one();
+
+        let acked = eventually(|| recording.ack_calls().len() == 1, Duration::from_secs(2)).await;
+        assert!(
+            acked,
+            "egress must dispatch ack_after_publish through the Transport trait \
+             so BusTransport's override fires on barrier-final"
+        );
+        assert_eq!(recording.ack_calls()[0], hash);
+        assert!(ack_barriers.is_empty());
+
+        cancel.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(1), egress).await;
+    }
+
     #[tokio::test]
     async fn egress_publish_in_flight_since_brackets_publish_call() {
         let dir = Arc::new(DirectionState::new());
         let dest = MockDest::new();
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None]);
+        let children = stub_children(2);
         let cancel = CancellationToken::new();
 
         let msg = sample_message("@a.ed25519", 1);
@@ -680,7 +847,7 @@ mod tests {
         let dir_clone = dir.clone();
         let dest_clone = dest.clone();
         let barriers_clone = ack_barriers.clone();
-        let bus_children_clone = bus_children.clone();
+        let children_clone = children.clone();
         let cancel_clone = cancel.clone();
         let egress = tokio::spawn(async move {
             run_egress(
@@ -688,7 +855,7 @@ mod tests {
                 dest_clone as Arc<dyn Transport>,
                 dir_clone,
                 barriers_clone,
-                bus_children_clone,
+                children_clone,
                 cancel_clone,
             )
             .await;
@@ -715,7 +882,7 @@ mod tests {
         let dir = Arc::new(DirectionState::new());
         let dest = MockDest::new();
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None]);
+        let children = stub_children(2);
         let cancel = CancellationToken::new();
 
         // Arm oldest_queued_at as ingress would.
@@ -727,7 +894,7 @@ mod tests {
         let dir_clone = dir.clone();
         let dest_clone = dest.clone();
         let barriers_clone = ack_barriers.clone();
-        let bus_children_clone = bus_children.clone();
+        let children_clone = children.clone();
         let cancel_clone = cancel.clone();
         let egress = tokio::spawn(async move {
             run_egress(
@@ -735,7 +902,7 @@ mod tests {
                 dest_clone as Arc<dyn Transport>,
                 dir_clone,
                 barriers_clone,
-                bus_children_clone,
+                children_clone,
                 cancel_clone,
             )
             .await;
@@ -767,7 +934,7 @@ mod tests {
         let dest1 = MockDest::new();
         let dest2 = MockDest::new();
         let ack_barriers: Arc<DashMap<String, Arc<AckBarrier>>> = Arc::new(DashMap::new());
-        let bus_children: Arc<Vec<Option<Arc<BusTransport>>>> = Arc::new(vec![None, None, None]);
+        let children = stub_children(3);
         let cancel = CancellationToken::new();
 
         let msg = sample_message("@a.ed25519", 1);
@@ -782,20 +949,22 @@ mod tests {
             let dir = dir1.clone();
             let dest = dest1.clone();
             let bars = ack_barriers.clone();
-            let buses = bus_children.clone();
+            let children_clone = children.clone();
             let cancel = cancel.clone();
             tokio::spawn(async move {
-                run_egress(1, dest as Arc<dyn Transport>, dir, bars, buses, cancel).await;
+                run_egress(1, dest as Arc<dyn Transport>, dir, bars, children_clone, cancel)
+                    .await;
             })
         };
         let e2 = {
             let dir = dir2.clone();
             let dest = dest2.clone();
             let bars = ack_barriers.clone();
-            let buses = bus_children.clone();
+            let children_clone = children.clone();
             let cancel = cancel.clone();
             tokio::spawn(async move {
-                run_egress(2, dest as Arc<dyn Transport>, dir, bars, buses, cancel).await;
+                run_egress(2, dest as Arc<dyn Transport>, dir, bars, children_clone, cancel)
+                    .await;
             })
         };
         dir1.egress_wake.notify_one();

--- a/src/transport/composite/egress.rs
+++ b/src/transport/composite/egress.rs
@@ -952,8 +952,15 @@ mod tests {
             let children_clone = children.clone();
             let cancel = cancel.clone();
             tokio::spawn(async move {
-                run_egress(1, dest as Arc<dyn Transport>, dir, bars, children_clone, cancel)
-                    .await;
+                run_egress(
+                    1,
+                    dest as Arc<dyn Transport>,
+                    dir,
+                    bars,
+                    children_clone,
+                    cancel,
+                )
+                .await;
             })
         };
         let e2 = {
@@ -963,8 +970,15 @@ mod tests {
             let children_clone = children.clone();
             let cancel = cancel.clone();
             tokio::spawn(async move {
-                run_egress(2, dest as Arc<dyn Transport>, dir, bars, children_clone, cancel)
-                    .await;
+                run_egress(
+                    2,
+                    dest as Arc<dyn Transport>,
+                    dir,
+                    bars,
+                    children_clone,
+                    cancel,
+                )
+                .await;
             })
         };
         dir1.egress_wake.notify_one();

--- a/src/transport/composite/health.rs
+++ b/src/transport/composite/health.rs
@@ -7,11 +7,10 @@
 //! construction of the returned struct.
 
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use std::time::Instant;
 
-use crate::transport::bus::BusTransport;
 use crate::transport::health::BridgeQueuesHealth;
+use crate::transport::trait_def::Transport;
 
 use super::direction::{DirectionState, BRIDGE_QUEUE_HIGH_WATERMARK};
 
@@ -22,17 +21,16 @@ use super::direction::{DirectionState, BRIDGE_QUEUE_HIGH_WATERMARK};
 /// rendered JSON stays consistent with the child's self-reported backend
 /// string.
 ///
-/// `bus_handle` — Wave 4 Step 22 retcon: when the child is a bus
-/// transport, the canonical `self_echo_total` counter lives on the bus
-/// adapter itself (amendment §C.4 re-interpretation; self-echo is a
-/// bus-layer concern, not a direction concern). Pass `Some(bus)` for
-/// bus children so the aggregate reflects the live counter; pass `None`
-/// for gossip/other children and the fallback `DirectionState.self_echo_total`
-/// (always zero in practice) is used.
+/// `child` — Wave 4 Step 22 retcon: self-echo is a bus-layer concern
+/// (amendment §C.4). The child's `Transport::self_echo_total` returns the
+/// canonical counter for bus transports and the trait default `0` for
+/// gossip and other non-bus children. Pass `Some(child)` in production;
+/// `None` in test contexts that want the legacy `DirectionState.self_echo_total`
+/// fallback (always zero in practice).
 pub(crate) fn compute_bridge_queues_health(
     dir: &DirectionState,
     destination: &str,
-    bus_handle: Option<&Arc<BusTransport>>,
+    child: Option<&dyn Transport>,
 ) -> BridgeQueuesHealth {
     // Snapshot the queue map under a short lock. We compute depth_total
     // and authors_active from the same snapshot so the two numbers stay
@@ -81,12 +79,13 @@ pub(crate) fn compute_bridge_queues_health(
     // ensures a mis-routed write can't leak here.
     let last_error = dir.last_error.read().clone().map(sanitize_error_surface);
 
-    // Self-echo total: bus children read from BusTransport (canonical
-    // source, amendment §C.4 Wave 4 retcon). Non-bus children surface the
-    // direction-scoped counter, which is always zero since self-echo only
-    // applies to bus-sourced deliveries.
-    let self_echo_total = match bus_handle {
-        Some(bus) => bus.self_echo_total(),
+    // Self-echo total: production callers pass the child transport;
+    // `Transport::self_echo_total` is overridden by `BusTransport` to
+    // surface the canonical counter (amendment §C.4 Wave 4 retcon) and
+    // returns the trait default 0 for any non-bus child. The `None` arm
+    // is the legacy direction-scoped fallback used by isolated unit tests.
+    let self_echo_total = match child {
+        Some(c) => c.self_echo_total(),
         None => dir.self_echo_total.load(Ordering::Relaxed),
     };
 

--- a/src/transport/composite/transport.rs
+++ b/src/transport/composite/transport.rs
@@ -30,7 +30,6 @@ use tokio_util::sync::CancellationToken;
 use crate::error::{EgreError, Result};
 use crate::feed::models::Message;
 use crate::identity::PublicId;
-use crate::transport::bus::BusTransport;
 use crate::transport::filter::TopicFilter;
 use crate::transport::health::TransportHealth;
 use crate::transport::subscription::SubscriptionHandle;
@@ -40,39 +39,21 @@ use super::direction::{AckBarrier, DirectionState};
 
 /// How a child transport is attached to the composite.
 ///
-/// The composite cannot downcast `Arc<dyn Transport>` to `Arc<BusTransport>`
-/// at construction time (trait object erasure), but the egress task needs
-/// the concrete bus handle to call `ack_after_publish` on final-destination
-/// resolution. Callers (Wave 4's `main.rs`) still have the concrete type
-/// when they build the composite, so they pass both handles through
-/// `ChildSpec`. Non-bus children leave `bus_handle = None`.
+/// `ack_after_publish` and `self_echo_total` are now trait methods with
+/// default no-op / default-zero implementations; bus-specific concerns are
+/// resolved through trait dispatch on `Arc<dyn Transport>`, so the composite
+/// no longer needs to retain a parallel concrete bus handle.
 pub struct ChildSpec {
     /// The transport as a trait object — used for `publish`, `subscribe`,
-    /// `request_from`, `start`, `shutdown`, `health`.
+    /// `request_from`, `start`, `shutdown`, `health`, and the composite-only
+    /// extension hooks `ack_after_publish` / `self_echo_total`.
     pub transport: Arc<dyn Transport>,
-    /// When the child is a `BusTransport`, the concrete handle is retained
-    /// here so `egress` can call `ack_after_publish(hash)` after a
-    /// bus-sourced message has resolved against every destination. `None`
-    /// for gossip and other non-bus children.
-    pub bus_handle: Option<Arc<BusTransport>>,
 }
 
 impl ChildSpec {
-    /// Construct a gossip-style (no-ack) child spec.
-    pub fn gossip(transport: Arc<dyn Transport>) -> Self {
-        Self {
-            transport,
-            bus_handle: None,
-        }
-    }
-
-    /// Construct a bus child spec — the concrete handle is required for
-    /// the egress → ack_after_publish path.
-    pub fn bus(transport: Arc<dyn Transport>, bus_handle: Arc<BusTransport>) -> Self {
-        Self {
-            transport,
-            bus_handle: Some(bus_handle),
-        }
+    /// Construct a child spec from any `Transport` implementation.
+    pub fn new(transport: Arc<dyn Transport>) -> Self {
+        Self { transport }
     }
 }
 
@@ -84,13 +65,10 @@ impl ChildSpec {
 /// the `Transport` trait only.
 #[allow(dead_code)] // consumed in Steps 16–20 (publish, ingress, egress, start, shutdown, health)
 pub struct CompositeTransport {
-    /// Child transports as trait objects. Index = `TransportId`.
+    /// Child transports as trait objects. Index = `TransportId`. Bus-specific
+    /// hooks (`ack_after_publish`, `self_echo_total`) are dispatched through
+    /// the trait so no parallel concrete handle is retained.
     pub(crate) children: Vec<Arc<dyn Transport>>,
-
-    /// Concrete bus handles parallel to `children`. `bus_children[i]` is
-    /// `Some(bus)` iff child `i` is a bus transport. Populated from
-    /// `ChildSpec.bus_handle` at construction.
-    pub(crate) bus_children: Vec<Option<Arc<BusTransport>>>,
 
     /// One `DirectionState` per child. `directions[j]` holds queues for
     /// messages going TO child `j` (from every `i != j`).
@@ -144,19 +122,14 @@ impl CompositeTransport {
                 ),
             });
         }
-        let mut children = Vec::with_capacity(specs.len());
-        let mut bus_children = Vec::with_capacity(specs.len());
-        for spec in specs {
-            children.push(spec.transport);
-            bus_children.push(spec.bus_handle);
-        }
+        let children: Vec<Arc<dyn Transport>> =
+            specs.into_iter().map(|spec| spec.transport).collect();
         let directions = (0..children.len())
             .map(|_| Arc::new(DirectionState::new()))
             .collect();
 
         Ok(Self {
             children,
-            bus_children,
             directions,
             started: AtomicBool::new(false),
             cancel: CancellationToken::new(),
@@ -386,7 +359,7 @@ impl Transport for CompositeTransport {
 
         let num_children = self.children.len();
         let directions_arc = Arc::new(self.directions.clone());
-        let bus_children_arc = Arc::new(self.bus_children.clone());
+        let children_arc = Arc::new(self.children.clone());
 
         // 2. Spawn one ingress task per child (source).
         let mut ingress_handles = Vec::with_capacity(num_children);
@@ -417,10 +390,10 @@ impl Transport for CompositeTransport {
             let dest = child.clone();
             let dir = self.directions[j].clone();
             let barriers = self.ack_barriers.clone();
-            let bus_children = bus_children_arc.clone();
+            let children = children_arc.clone();
             let cancel = self.cancel.clone();
             egress_handles.push(tokio::spawn(async move {
-                super::egress::run_egress(dest_id, dest, dir, barriers, bus_children, cancel).await;
+                super::egress::run_egress(dest_id, dest, dir, barriers, children, cancel).await;
             }));
         }
         *self.egress_handles.lock().await = Some(egress_handles);
@@ -523,15 +496,13 @@ impl Transport for CompositeTransport {
             .map(|(j, child)| {
                 let mut child_health = child.health();
                 let destination = child_health.backend;
-                // Wave 4 Step 22 retcon: bus children surface their
-                // canonical self_echo_total counter via the bus handle;
-                // gossip children fall back to `DirectionState`'s
-                // (always-zero) counter.
-                let bus_handle = self.bus_children[j].as_ref();
+                // Wave 4 Step 22 retcon: self-echo lives on the bus adapter
+                // itself (amendment §C.4). The trait's default returns 0
+                // for non-bus children, so the call is unconditional.
                 child_health.bridge_queues = Some(super::health::compute_bridge_queues_health(
                     &self.directions[j],
                     destination,
-                    bus_handle,
+                    Some(child.as_ref() as &dyn Transport),
                 ));
                 child_health
             })
@@ -742,7 +713,7 @@ mod tests {
         let empty = CompositeTransport::new(vec![]);
         assert!(empty.is_err(), "zero children must be rejected");
         let single =
-            CompositeTransport::new(vec![ChildSpec::gossip(Arc::new(StubChild) as Arc<_>)]);
+            CompositeTransport::new(vec![ChildSpec::new(Arc::new(StubChild) as Arc<_>)]);
         assert!(
             single.is_err(),
             "single-child composite is a pass-through; caller must use child directly"
@@ -752,17 +723,13 @@ mod tests {
     #[test]
     fn new_populates_one_direction_per_child() {
         let specs = vec![
-            ChildSpec::gossip(Arc::new(StubChild) as Arc<_>),
-            ChildSpec::gossip(Arc::new(StubChild) as Arc<_>),
-            ChildSpec::gossip(Arc::new(StubChild) as Arc<_>),
+            ChildSpec::new(Arc::new(StubChild) as Arc<_>),
+            ChildSpec::new(Arc::new(StubChild) as Arc<_>),
+            ChildSpec::new(Arc::new(StubChild) as Arc<_>),
         ];
         let composite = CompositeTransport::new(specs).unwrap();
         assert_eq!(composite.children.len(), 3);
-        assert_eq!(composite.bus_children.len(), 3);
         assert_eq!(composite.directions.len(), 3);
-        for slot in &composite.bus_children {
-            assert!(slot.is_none(), "gossip spec leaves bus_handle=None");
-        }
         for dir in &composite.directions {
             assert!(dir.queues.lock().is_empty());
             assert_eq!(dir.backpressure_events.load(Ordering::Relaxed), 0);
@@ -772,8 +739,8 @@ mod tests {
     #[test]
     fn new_starts_cancel_token_unfired() {
         let composite = CompositeTransport::new(vec![
-            ChildSpec::gossip(Arc::new(StubChild) as Arc<_>),
-            ChildSpec::gossip(Arc::new(StubChild) as Arc<_>),
+            ChildSpec::new(Arc::new(StubChild) as Arc<_>),
+            ChildSpec::new(Arc::new(StubChild) as Arc<_>),
         ])
         .unwrap();
         assert!(
@@ -792,9 +759,9 @@ mod tests {
         let mock_b = MockChild::new();
         let mock_c = MockChild::new();
         let composite = CompositeTransport::new(vec![
-            ChildSpec::gossip(mock_a.clone() as Arc<_>),
-            ChildSpec::gossip(mock_b.clone() as Arc<_>),
-            ChildSpec::gossip(mock_c.clone() as Arc<_>),
+            ChildSpec::new(mock_a.clone() as Arc<_>),
+            ChildSpec::new(mock_b.clone() as Arc<_>),
+            ChildSpec::new(mock_c.clone() as Arc<_>),
         ])
         .unwrap();
         let msg = sample_message("@alice.ed25519", 1);
@@ -815,9 +782,9 @@ mod tests {
         mock_b.set_publish_error("simulated bus publish failure");
         let mock_c = MockChild::new();
         let composite = CompositeTransport::new(vec![
-            ChildSpec::gossip(mock_a.clone() as Arc<_>),
-            ChildSpec::gossip(mock_b.clone() as Arc<_>),
-            ChildSpec::gossip(mock_c.clone() as Arc<_>),
+            ChildSpec::new(mock_a.clone() as Arc<_>),
+            ChildSpec::new(mock_b.clone() as Arc<_>),
+            ChildSpec::new(mock_c.clone() as Arc<_>),
         ])
         .unwrap();
         let msg = sample_message("@alice.ed25519", 1);
@@ -848,8 +815,8 @@ mod tests {
         mock_a.push_subscribe_message(sample_message("@alice.ed25519", 1));
         mock_b.push_subscribe_message(sample_message("@bob.ed25519", 1));
         let composite = CompositeTransport::new(vec![
-            ChildSpec::gossip(mock_a.clone() as Arc<_>),
-            ChildSpec::gossip(mock_b.clone() as Arc<_>),
+            ChildSpec::new(mock_a.clone() as Arc<_>),
+            ChildSpec::new(mock_b.clone() as Arc<_>),
         ])
         .unwrap();
         let (_handle, mut stream) = composite
@@ -886,8 +853,8 @@ mod tests {
         mock_b.set_request_from_stream(expected.clone());
 
         let composite = CompositeTransport::new(vec![
-            ChildSpec::gossip(mock_a as Arc<_>),
-            ChildSpec::gossip(mock_b as Arc<_>),
+            ChildSpec::new(mock_a as Arc<_>),
+            ChildSpec::new(mock_b as Arc<_>),
         ])
         .unwrap();
         let mut stream = composite
@@ -996,8 +963,8 @@ mod tests {
         let (mock_b, _tx_b) = FullMock::new(16);
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a.clone() as Arc<_>),
-                ChildSpec::gossip(mock_b.clone() as Arc<_>),
+                ChildSpec::new(mock_a.clone() as Arc<_>),
+                ChildSpec::new(mock_b.clone() as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1029,8 +996,8 @@ mod tests {
         let (mock_b, _tx_b) = FullMock::new(16);
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a.clone() as Arc<_>),
-                ChildSpec::gossip(mock_b.clone() as Arc<_>),
+                ChildSpec::new(mock_a.clone() as Arc<_>),
+                ChildSpec::new(mock_b.clone() as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1057,8 +1024,8 @@ mod tests {
         let (mock_b, _tx_b) = FullMock::new(16);
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a as Arc<_>),
-                ChildSpec::gossip(mock_b as Arc<_>),
+                ChildSpec::new(mock_a as Arc<_>),
+                ChildSpec::new(mock_b as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1087,8 +1054,8 @@ mod tests {
         let (mock_b, _tx_b) = FullMock::new(16);
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a as Arc<_>),
-                ChildSpec::gossip(mock_b as Arc<_>),
+                ChildSpec::new(mock_a as Arc<_>),
+                ChildSpec::new(mock_b as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1127,8 +1094,8 @@ mod tests {
         let (mock_b, _tx_b) = FullMock::new(16);
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a as Arc<_>),
-                ChildSpec::gossip(mock_b as Arc<_>),
+                ChildSpec::new(mock_a as Arc<_>),
+                ChildSpec::new(mock_b as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1148,8 +1115,8 @@ mod tests {
         let (mock_b, _tx_b) = FullMock::new(16);
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a as Arc<_>),
-                ChildSpec::gossip(mock_b as Arc<_>),
+                ChildSpec::new(mock_a as Arc<_>),
+                ChildSpec::new(mock_b as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1167,8 +1134,8 @@ mod tests {
         let (mock_b, _tx_b) = FullMock::new(16);
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a as Arc<_>),
-                ChildSpec::gossip(mock_b as Arc<_>),
+                ChildSpec::new(mock_a as Arc<_>),
+                ChildSpec::new(mock_b as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1196,8 +1163,8 @@ mod tests {
         // Both mocks report connected=true by default.
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a.clone() as Arc<_>),
-                ChildSpec::gossip(mock_b.clone() as Arc<_>),
+                ChildSpec::new(mock_a.clone() as Arc<_>),
+                ChildSpec::new(mock_b.clone() as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1218,8 +1185,8 @@ mod tests {
         let (mock_b, _tx_b) = FullMock::new(16);
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(mock_a.clone() as Arc<_>),
-                ChildSpec::gossip(mock_b.clone() as Arc<_>),
+                ChildSpec::new(mock_a.clone() as Arc<_>),
+                ChildSpec::new(mock_b.clone() as Arc<_>),
             ])
             .unwrap(),
         );
@@ -1259,8 +1226,8 @@ mod tests {
         mock_a.set_request_from_err("err_a");
         mock_b.set_request_from_err("err_b");
         let composite = CompositeTransport::new(vec![
-            ChildSpec::gossip(mock_a as Arc<_>),
-            ChildSpec::gossip(mock_b as Arc<_>),
+            ChildSpec::new(mock_a as Arc<_>),
+            ChildSpec::new(mock_b as Arc<_>),
         ])
         .unwrap();
         let err = match composite

--- a/src/transport/composite/transport.rs
+++ b/src/transport/composite/transport.rs
@@ -712,8 +712,7 @@ mod tests {
     fn new_rejects_fewer_than_two_children() {
         let empty = CompositeTransport::new(vec![]);
         assert!(empty.is_err(), "zero children must be rejected");
-        let single =
-            CompositeTransport::new(vec![ChildSpec::new(Arc::new(StubChild) as Arc<_>)]);
+        let single = CompositeTransport::new(vec![ChildSpec::new(Arc::new(StubChild) as Arc<_>)]);
         assert!(
             single.is_err(),
             "single-child composite is a pass-through; caller must use child directly"

--- a/src/transport/trait_def.rs
+++ b/src/transport/trait_def.rs
@@ -90,4 +90,29 @@ pub trait Transport: Send + Sync + 'static {
     /// Coarse liveness signal for `/v1/status`. Per-peer detail is adapter-
     /// internal (e.g. `gossip::health`); this is the wire-agnostic summary.
     fn health(&self) -> TransportHealth;
+
+    /// Composite-only extension hook (RFC 0002 §C.5): finalize broker-side
+    /// acknowledgment for a forwarded message after the per-message
+    /// `AckBarrier` resolves to zero.
+    ///
+    /// NOT a core transport invariant — only the bridge-mode composite calls
+    /// this on the SOURCE child after every destination has been published.
+    /// Implementations that have no broker-side ack concept (gossip, mock,
+    /// any pure peer-to-peer backend) MUST keep the default no-op.
+    /// `BusTransport` overrides this to drain its `pending_acks` map.
+    async fn ack_after_publish(&self, _message_hash: &str) -> Result<()> {
+        Ok(())
+    }
+
+    /// Composite-only extension hook (amendment §C.4 retcon): expose the
+    /// canonical self-echo counter so the bridge can surface it through
+    /// `BridgeQueuesHealth`.
+    ///
+    /// NOT a core transport invariant — only the composite's health
+    /// aggregation reads this. Implementations with no self-echo path
+    /// (gossip, mock) MUST keep the default zero. `BusTransport` overrides
+    /// to surface its incremented atomic.
+    fn self_echo_total(&self) -> u64 {
+        0
+    }
 }

--- a/tests/b8_cross_transport_dedup.rs
+++ b/tests/b8_cross_transport_dedup.rs
@@ -83,8 +83,8 @@ impl Harness {
 
         let composite = Arc::new(
             CompositeTransport::new(vec![
-                ChildSpec::gossip(child_a.clone() as Arc<dyn Transport>),
-                ChildSpec::gossip(child_b.clone() as Arc<dyn Transport>),
+                ChildSpec::new(child_a.clone() as Arc<dyn Transport>),
+                ChildSpec::new(child_b.clone() as Arc<dyn Transport>),
             ])
             .expect("two-child composite construction"),
         );


### PR DESCRIPTION
## Summary

Five-commit refactor pass on egregore as part of the umbrella `/code:orchestrate` simplification sweep. Net +136 lines across 15 files (most of that is new test fixtures for the trait-dispatch lock).

| # | Commit | Subject |
|---|--------|---------|
| 1 | `00b213f` | feat: hoist `decrypt_for_local_identity` into `feed::private_box` (B7) |
| 2 | `275c1b2` | refactor: extract `insert_message_row` shared persistence helper (B2) |
| 3 | `53e57dd` | refactor: `response::run_blocking` helper, collapses `spawn_blocking`+axum boilerplate; 5 handlers in `routes_feed.rs` migrated (S1) |
| 4 | `ca2cde9` | refactor: bulk-apply `run_blocking` to follows/topics/retention/peers — 12 more handlers (S1 cont.) |
| 5 | `e4967fa` | refactor: hoist composite extension hooks (`ack_after_publish`, `self_echo_total`) onto `Transport` trait, drop `ChildSpec::bus_handle` parallel-Vec (C3) |

### Composite trait hoist (C3)

The composite previously kept a parallel `Vec<Option<Arc<BusTransport>>>` alongside `children: Vec<Arc<dyn Transport>>` purely so the egress task could call BusTransport-specific methods. This commit:

- Adds two trait methods to `Transport` with safe defaults (`ack_after_publish`: `Ok(())`, `self_echo_total`: `0`). Documented as **composite-only extension hooks, not core invariants**.
- `BusTransport` overrides both, delegating to existing inherent methods.
- `ChildSpec` collapses to a single field with a single `ChildSpec::new(transport)` constructor.
- `run_egress` calls `source.ack_after_publish(hash)` unconditionally — gossip's no-op default makes the call free.
- New test `egress_dispatches_ack_after_publish_through_trait` locks the trait-dispatch contract using a `RecordingSource` mock without needing live NATS.

### Public API change

`ChildSpec::gossip` and `ChildSpec::bus` are removed. The only out-of-crate callers are `src/main.rs` and `tests/b8_cross_transport_dedup.rs` (both updated). External consumers of the egregore crate as a library would need to migrate to `ChildSpec::new(transport)`.

### `run_blocking` helper (S1)

Collapses the repeated `tokio::task::spawn_blocking` + axum response error mapping that was duplicated in every SQLite-touching handler. Helper lives in `src/api/response.rs`. Documented exception cases (group "already exists" → 409, status/health intentional degradation, peer aggregation `unwrap_or_default`) keep the inline match — those handlers genuinely need to introspect or degrade rather than short-circuit.

## Test plan

- [x] `cargo build --lib`
- [x] `cargo build --tests`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test --lib` — 483 passing (+1 new)
- [x] All integration suites passing (one pre-existing flake on `b8_private_box_messages_forward_unchanged` cleared on rerun, same flake observed on PR #132)
- [x] Codex pair-reviewed: design + implementation rounds for C3 and S1 (rules: >10 LOC new logic, fresh session per task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)