### PR TITLE
refactor(transport): drop stale dead_code markers (Phase 4 follow-up)

### DIFF
--- a/src/transport/bus/transport.rs
+++ b/src/transport/bus/transport.rs
@@ -428,7 +428,9 @@ impl BusTransport {
     ///
     /// Uses `remove()` to both drop the handle and call `.ack()` on it.
     /// The `DashMap::remove` returns the `(K, V)` tuple on hit.
-    #[allow(dead_code)] // wired by CompositeTransport egress in Wave 3
+    ///
+    /// Reached via the `Transport::ack_after_publish` override below; the
+    /// composite egress task dispatches through the trait on barrier-final.
     pub async fn ack_after_publish(&self, message_hash: &str) -> Result<()> {
         if let Some((_, nats_msg)) = self.pending_acks.remove(message_hash) {
             nats_msg.ack().await.map_err(|_e| EgreError::Peer {
@@ -438,10 +440,13 @@ impl BusTransport {
         Ok(())
     }
 
-    /// Release the ack handle for `message_hash` WITHOUT acking. Called
-    /// on shutdown or error paths so NATS `ack_wait` expires and the
-    /// message is redelivered. Amendment §C.2.
-    #[allow(dead_code)] // wired by CompositeTransport egress in Wave 3
+    /// Release the ack handle for `message_hash` WITHOUT acking. Intended
+    /// for shutdown or error paths so NATS `ack_wait` expires and the
+    /// message is redelivered (amendment §C.2). Currently unwired — egress
+    /// resolves all barriers via `ack_after_publish`. Retained as the
+    /// documented §C.2 affordance; a future commit wiring shutdown-time
+    /// abandon should drop the `#[allow(dead_code)]`.
+    #[allow(dead_code)]
     pub fn abandon_ack(&self, message_hash: &str) {
         self.pending_acks.remove(message_hash);
     }

--- a/src/transport/composite/transport.rs
+++ b/src/transport/composite/transport.rs
@@ -63,7 +63,6 @@ impl ChildSpec {
 /// (`ingress`, `egress`, `health`) can read them without an accessor
 /// ceremony. Callers outside the crate construct via `new` + drive via
 /// the `Transport` trait only.
-#[allow(dead_code)] // consumed in Steps 16–20 (publish, ingress, egress, start, shutdown, health)
 pub struct CompositeTransport {
     /// Child transports as trait objects. Index = `TransportId`. Bus-specific
     /// hooks (`ack_after_publish`, `self_echo_total`) are dispatched through


### PR DESCRIPTION
## Summary

Phase 4 reviewer sweep on the orchestrate refactor pass (PR #134) flagged three `#[allow(dead_code)]` annotations in the transport layer whose comments became misleading after the C3 trait hoist. Mechanical cleanup:

- `BusTransport::ack_after_publish` — dropped the allow; inherent is reached via the new `Transport` trait override. Updated doc comment to reflect the dispatch path.
- `BusTransport::abandon_ack` — kept the allow (still genuinely unwired), but rewrote the comment to reflect actual state. Retained as the documented §C.2 affordance for a future shutdown-time wiring commit.
- `CompositeTransport` struct — dropped the "consumed in Steps 16–20" process-narrative annotation. The struct is fully consumed.

No semantic change.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 483 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)